### PR TITLE
JIT Cache changes (again)

### DIFF
--- a/src/core/ee/ee_jit64.cpp
+++ b/src/core/ee/ee_jit64.cpp
@@ -156,10 +156,11 @@ EEJitBlockRecord* EE_JIT64::recompile_block(EmotionEngine& ee, IR::Block& block)
         cleanup_recompiler(ee, true);
 
     //Switch the block's privileges from RW to RX.
-    jit_heap.insert_block(ee.get_PC(), &jit_block);
-
     //cache.print_block();
     //cache.print_literal_pool();
+    return jit_heap.insert_block(ee.get_PC(), &jit_block);
+
+
 }
 
 void EE_JIT64::emit_instruction(EmotionEngine &ee, IR::Instruction &instr)

--- a/src/core/ee/ee_jit64.hpp
+++ b/src/core/ee/ee_jit64.hpp
@@ -68,7 +68,8 @@ class EE_JIT64
 private:
     AllocReg xmm_regs[16];
     AllocReg int_regs[16];
-    JitCache cache;
+    JitBlock jit_block;
+    EEJitHeap jit_heap;
     Emitter64 emitter;
     EE_JitTranslator ir;
 
@@ -303,7 +304,7 @@ private:
     // Recompile + Cleanup
     void emit_prologue();
     void emit_instruction(EmotionEngine &ee, IR::Instruction &instr);
-    void recompile_block(EmotionEngine& ee, IR::Block& block);
+    EEJitBlockRecord* recompile_block(EmotionEngine& ee, IR::Block& block);
     void cleanup_recompiler(EmotionEngine& ee, bool clear_regs);
     void emit_epilogue();
 public:

--- a/src/core/ee/vu_jit64.cpp
+++ b/src/core/ee/vu_jit64.cpp
@@ -2945,7 +2945,7 @@ void VU_JIT64::recompile_block(VectorUnit& vu, IR::Block& block)
 
     //Switch the block's privileges from RW to RX.
     cache.set_current_block_rx();
-    //cache.print_current_block();
+    //cache.print_block();
     //cache.print_literal_pool();
 }
 
@@ -3104,7 +3104,7 @@ uint8_t* exec_block(VU_JIT64& jit, VectorUnit& vu)
         IR::Block block = jit.ir.translate(vu, vu.get_instr_mem(), jit.prev_pc);
         jit.recompile_block(vu, block);
     }
-    return jit.cache.get_current_block_start();
+    return jit.cache.get_code_start();
 }
 
 uint16_t VU_JIT64::run(VectorUnit& vu)

--- a/src/core/ee/vu_jit64.hpp
+++ b/src/core/ee/vu_jit64.hpp
@@ -35,7 +35,7 @@ class VU_JIT64
     private:
         AllocReg xmm_regs[16];
         AllocReg int_regs[16];
-        JitCache cache;
+        JitBlock cache;
         Emitter64 emitter;
         VU_JitTranslator ir;
 

--- a/src/core/ee/vu_jit64.hpp
+++ b/src/core/ee/vu_jit64.hpp
@@ -35,7 +35,8 @@ class VU_JIT64
     private:
         AllocReg xmm_regs[16];
         AllocReg int_regs[16];
-        JitBlock cache;
+        JitBlock jit_block;
+        VUJitHeap jit_heap;
         Emitter64 emitter;
         VU_JitTranslator ir;
 
@@ -181,7 +182,7 @@ class VU_JIT64
 
         void emit_prologue();
         void emit_instruction(VectorUnit& vu, IR::Instruction& instr);
-        void recompile_block(VectorUnit& vu, IR::Block& block);
+        VUJitBlockRecord* recompile_block(VectorUnit& vu, IR::Block& block);
         //uint8_t* exec_block(VectorUnit& vu);
         void cleanup_recompiler(VectorUnit& vu, bool clear_regs);
         void emit_epilogue();

--- a/src/core/gsthread.cpp
+++ b/src/core/gsthread.cpp
@@ -81,7 +81,8 @@ float interpolate_f(int32_t x, float u1, int32_t x1, float u2, int32_t x2)
 const unsigned int GraphicsSynthesizerThread::max_vertices[8] = {1, 2, 2, 3, 3, 3, 2, 0};
 
 GraphicsSynthesizerThread::GraphicsSynthesizerThread()
-    : frame_complete(false), local_mem(nullptr), emitter_dp(&jit_draw_pixel_block),
+    : frame_complete(false), local_mem(nullptr), jit_draw_pixel_block("GS-pixel"), jit_tex_lookup_block("GS-texture"),
+    emitter_dp(&jit_draw_pixel_block),
       emitter_tex(&jit_tex_lookup_block)
 {
     //Initialize swizzling tables
@@ -148,8 +149,8 @@ GraphicsSynthesizerThread::GraphicsSynthesizerThread()
         log2_lookup[i][3] = ldexp(calculation, 3);
     }
 
-    jit_draw_pixel_block.flush_all_blocks();
-    jit_tex_lookup_block.flush_all_blocks();
+    jit_draw_pixel_heap.flush_all_blocks();
+    jit_tex_lookup_heap.flush_all_blocks();
 
     thread = std::thread(&GraphicsSynthesizerThread::event_loop, this);
 }
@@ -479,8 +480,8 @@ void GraphicsSynthesizerThread::reset()
     jit_draw_pixel_func = nullptr;
     jit_tex_lookup_func = nullptr;
 
-    jit_tex_lookup_block.flush_all_blocks();
-    jit_draw_pixel_block.flush_all_blocks();
+    jit_tex_lookup_heap.flush_all_blocks();
+    jit_draw_pixel_heap.flush_all_blocks();
 
     reset_fifos();
 }
@@ -3877,27 +3878,29 @@ void GraphicsSynthesizerThread::update_tex_lookup_state()
 
 uint8_t* GraphicsSynthesizerThread::get_jitted_draw_pixel(uint64_t state)
 {
-    if (jit_draw_pixel_block.find_block(BlockState{0, 0, 0, state, 0}) == nullptr)
+    GSPixelJitBlockRecord* found_block = jit_draw_pixel_heap.find_block(state);
+    if (!found_block)
     {
         printf("[GS_t] RECOMPILING DRAW PIXEL %llX\n", state);
-        recompile_draw_pixel(state);
+        found_block = recompile_draw_pixel(state);
     }
-    return jit_draw_pixel_block.get_code_start();
+    return (uint8_t*)found_block->code_start;
 }
 
 uint8_t* GraphicsSynthesizerThread::get_jitted_tex_lookup(uint64_t state)
 {
-    if (jit_tex_lookup_block.find_block(BlockState{0, 0, 0, state, 0}) == nullptr)
+    GSTextureJitBlockRecord* found_block = jit_tex_lookup_heap.find_block(state);
+    if (!found_block)
     {
         printf("[GS_t] RECOMPILING TEX LOOKUP %llX\n", state);
-        recompile_tex_lookup(state);
+        found_block = recompile_tex_lookup(state);
     }
-    return jit_tex_lookup_block.get_code_start();
+    return (uint8_t*)found_block->code_start;
 }
 
-void GraphicsSynthesizerThread::recompile_draw_pixel(uint64_t state)
+GSPixelJitBlockRecord* GraphicsSynthesizerThread::recompile_draw_pixel(uint64_t state)
 {
-    jit_draw_pixel_block.alloc_block(BlockState{0, 0, 0, state, 0});
+    jit_draw_pixel_block.clear();
 
     //Prologue - create stack frame and save registers
     emitter_dp.PUSH(RBP);
@@ -4155,7 +4158,8 @@ void GraphicsSynthesizerThread::recompile_draw_pixel(uint64_t state)
     jit_epilogue_draw_pixel();
     jit_draw_pixel_block.print_block();
     jit_draw_pixel_block.print_literal_pool();
-    jit_draw_pixel_block.set_current_block_rx();
+    //jit_draw_pixel_block.set_current_block_rx();
+    return jit_draw_pixel_heap.insert_block(state, &jit_draw_pixel_block);
 }
 
 void GraphicsSynthesizerThread::recompile_alpha_test()
@@ -4479,9 +4483,9 @@ void GraphicsSynthesizerThread::jit_epilogue_draw_pixel()
     emitter_dp.RET();
 }
 
-void GraphicsSynthesizerThread::recompile_tex_lookup(uint64_t state)
+GSTextureJitBlockRecord* GraphicsSynthesizerThread::recompile_tex_lookup(uint64_t state)
 {
-    jit_tex_lookup_block.alloc_block(BlockState{0, 0, 0, state, 0});
+    jit_tex_lookup_block.clear();
 
     emitter_tex.PUSH(RBP);
     emitter_tex.SUB64_REG_IMM(0x100, RSP);
@@ -4851,7 +4855,8 @@ void GraphicsSynthesizerThread::recompile_tex_lookup(uint64_t state)
 
     jit_tex_lookup_block.print_block();
     jit_tex_lookup_block.print_literal_pool();
-    jit_tex_lookup_block.set_current_block_rx();
+    //jit_tex_lookup_block.set_current_block_rx();
+    return jit_tex_lookup_heap.insert_block(state, &jit_tex_lookup_block);
 }
 
 void GraphicsSynthesizerThread::recompile_clut_lookup()

--- a/src/core/gsthread.hpp
+++ b/src/core/gsthread.hpp
@@ -365,7 +365,7 @@ class GraphicsSynthesizerThread
         GSContext* current_ctx;
 
         Emitter64 emitter_dp, emitter_tex;
-        JitCache jit_draw_pixel_cache, jit_tex_lookup_cache;
+        JitBlock jit_draw_pixel_block, jit_tex_lookup_block;
         uint8_t* jit_draw_pixel_func;
         uint8_t* jit_tex_lookup_func;
 

--- a/src/core/gsthread.hpp
+++ b/src/core/gsthread.hpp
@@ -364,8 +364,11 @@ class GraphicsSynthesizerThread
         GSContext context1, context2;
         GSContext* current_ctx;
 
-        Emitter64 emitter_dp, emitter_tex;
         JitBlock jit_draw_pixel_block, jit_tex_lookup_block;
+        Emitter64 emitter_dp, emitter_tex;
+
+        GSPixelJitHeap jit_draw_pixel_heap;
+        GSTextureJitHeap jit_tex_lookup_heap;
         uint8_t* jit_draw_pixel_func;
         uint8_t* jit_tex_lookup_func;
 
@@ -459,7 +462,7 @@ class GraphicsSynthesizerThread
         void update_draw_pixel_state();
         void update_tex_lookup_state();
         uint8_t* get_jitted_draw_pixel(uint64_t state);
-        void recompile_draw_pixel(uint64_t state);
+        GSPixelJitBlockRecord* recompile_draw_pixel(uint64_t state);
         void recompile_alpha_test();
         void recompile_depth_test();
         void recompile_alpha_blend();
@@ -467,7 +470,7 @@ class GraphicsSynthesizerThread
         void jit_epilogue_draw_pixel();
 
         uint8_t* get_jitted_tex_lookup(uint64_t state);
-        void recompile_tex_lookup(uint64_t state);
+        GSTextureJitBlockRecord* recompile_tex_lookup(uint64_t state);
         void recompile_clut_lookup();
         void recompile_csm2_lookup();
         void recompile_convert_16bit_tex(REG_64 color, REG_64 temp, REG_64 temp2);

--- a/src/core/jitcommon/emitter64.cpp
+++ b/src/core/jitcommon/emitter64.cpp
@@ -2,7 +2,7 @@
 
 #define DISP32 0b101
 
-Emitter64::Emitter64(JitCache* cache) : cache(cache)
+Emitter64::Emitter64(JitBlock* cache) : block(cache)
 {
 
 }
@@ -10,13 +10,13 @@ Emitter64::Emitter64(JitCache* cache) : cache(cache)
 void Emitter64::rex_r(REG_64 reg)
 {
     if (reg & 0x8)
-        cache->write<uint8_t>(0x44);
+        block->write<uint8_t>(0x44);
 }
 
 void Emitter64::rex_rm(REG_64 rm)
 {
     if (rm & 0x8)
-        cache->write<uint8_t>(0x41);
+        block->write<uint8_t>(0x41);
 }
 
 void Emitter64::rex_r_rm(REG_64 reg, REG_64 rm)
@@ -28,7 +28,7 @@ void Emitter64::rex_r_rm(REG_64 reg, REG_64 rm)
         rex |= 0x1;
 
     if (rex & 0xF)
-        cache->write<uint8_t>(rex);
+        block->write<uint8_t>(rex);
 }
 
 void Emitter64::rexw_r(REG_64 reg)
@@ -36,7 +36,7 @@ void Emitter64::rexw_r(REG_64 reg)
     uint8_t rex = 0x48;
     if (reg & 0x8)
         rex |= 0x4;
-    cache->write<uint8_t>(rex);
+    block->write<uint8_t>(rex);
 }
 
 void Emitter64::rexw_rm(REG_64 rm)
@@ -44,7 +44,7 @@ void Emitter64::rexw_rm(REG_64 rm)
     uint8_t rex = 0x48;
     if (rm & 0x8)
         rex |= 0x1;
-    cache->write<uint8_t>(rex);
+    block->write<uint8_t>(rex);
 }
 
 void Emitter64::rexw_r_rm(REG_64 reg, REG_64 rm)
@@ -54,7 +54,7 @@ void Emitter64::rexw_r_rm(REG_64 reg, REG_64 rm)
         rex |= 0x4;
     if (rm & 0x8)
         rex |= 0x1;
-    cache->write<uint8_t>(rex);
+    block->write<uint8_t>(rex);
 }
 
 void Emitter64::vex(REG_64 source, REG_64 source2, REG_64 dest, bool packed)
@@ -67,198 +67,196 @@ void Emitter64::vex(REG_64 source, REG_64 source2, REG_64 dest, bool packed)
 
 void Emitter64::vex2(REG_64 source, REG_64 dest, bool packed)
 {
-    cache->write<uint8_t>(0xC5);
+    block->write<uint8_t>(0xC5);
     uint8_t result = 0xF8;
     if (!packed)
         result |= 0x2;
     if (dest & 0x8)
         result -= 0x80;
     result += -(source << 3);
-    cache->write<uint8_t>(result);
+    block->write<uint8_t>(result);
 }
 
 void Emitter64::vex3(REG_64 source, REG_64 source2, REG_64 dest, bool packed)
 {
-    cache->write<uint8_t>(0xC4);
+    block->write<uint8_t>(0xC4);
     uint8_t result = 0xC1;
     if (dest & 0x8)
         result -= 0x80;
-    cache->write<uint8_t>(result);
+    block->write<uint8_t>(result);
     result = 0x78;
     if (!packed)
         result |= 0x2;
     result += -(source << 3);
-    cache->write<uint8_t>(result);
+    block->write<uint8_t>(result);
 }
 
 void Emitter64::modrm(uint8_t mode, uint8_t reg, uint8_t rm)
 {
-    cache->write<uint8_t>(((mode & 0x3) << 6) | ((reg & 0x7) << 3) | (rm & 0x7));
+    block->write<uint8_t>(((mode & 0x3) << 6) | ((reg & 0x7) << 3) | (rm & 0x7));
 }
 
 int Emitter64::get_rip_offset(uint64_t addr)
 {
-    int64_t offset = (uint64_t)cache->get_literal_offset<uint64_t>(addr);
-    offset -= (uint64_t)cache->get_current_block_pos();
+    int64_t offset = (uint64_t)block->get_literal_offset<uint64_t>(addr);
+    offset -= (uint64_t) block->get_code_pos();
     return offset;
 }
 
 void Emitter64::load_addr(uint64_t addr, REG_64 dest)
 {
-    uint8_t* start = cache->get_current_block_start();
-    uint8_t* pos = cache->get_current_block_pos();
     int offset = get_rip_offset(addr);
     rexw_r(dest);
-    cache->write<uint8_t>(0x8B);
+    block->write<uint8_t>(0x8B);
     modrm(0, dest, DISP32);
-    cache->write<uint32_t>(offset - 7);
+    block->write<uint32_t>(offset - 7);
 }
 
 void Emitter64::ADD16_REG(REG_64 source, REG_64 dest)
 {
-    cache->write<uint8_t>(0x66);
+    block->write<uint8_t>(0x66);
     rex_r_rm(source, dest);
-    cache->write<uint8_t>(0x01);
+    block->write<uint8_t>(0x01);
     modrm(0b11, source, dest);
 }
 
 void Emitter64::ADD16_REG_IMM(uint16_t imm, REG_64 dest)
 {
-    cache->write<uint8_t>(0x66);
+    block->write<uint8_t>(0x66);
     rex_rm(dest);
-    cache->write<uint8_t>(0x81);
+    block->write<uint8_t>(0x81);
     modrm(0b11, 0, dest);
-    cache->write<uint16_t>(imm);
+    block->write<uint16_t>(imm);
 }
 
 void Emitter64::ADD32_REG(REG_64 source, REG_64 dest)
 {
     rex_r_rm(source, dest);
-    cache->write<uint8_t>(0x01);
+    block->write<uint8_t>(0x01);
     modrm(0b11, source, dest);
 }
 
 void Emitter64::ADD32_REG_IMM(uint32_t imm, REG_64 dest)
 {
     rex_rm(dest);
-    cache->write<uint8_t>(0x81);
+    block->write<uint8_t>(0x81);
     modrm(0b11, 0, dest);
-    cache->write<uint32_t>(imm);
+    block->write<uint32_t>(imm);
 }
 
 void Emitter64::ADD64_REG(REG_64 source, REG_64 dest)
 {
     rexw_r_rm(source, dest);
-    cache->write<uint8_t>(0x01);
+    block->write<uint8_t>(0x01);
     modrm(0b11, source, dest);
 }
 
 void Emitter64::ADD64_REG_IMM(uint32_t imm, REG_64 dest)
 {
     rexw_rm(dest);
-    cache->write<uint8_t>(0x81);
+    block->write<uint8_t>(0x81);
     modrm(0b11, 0, dest);
-    cache->write<uint32_t>(imm);
+    block->write<uint32_t>(imm);
 }
 
 void Emitter64::INC16(REG_64 dest)
 {
-    cache->write<uint8_t>(0x66);
+    block->write<uint8_t>(0x66);
     rex_rm(dest);
-    cache->write<uint8_t>(0xFF);
+    block->write<uint8_t>(0xFF);
     modrm(0b11, 0, dest);
 }
 
 void Emitter64::AND8_REG_IMM(uint8_t imm, REG_64 dest)
 {
     rex_rm(dest);
-    cache->write<uint8_t>(0x80);
+    block->write<uint8_t>(0x80);
     modrm(0b11, 4, dest);
-    cache->write<uint8_t>(imm);
+    block->write<uint8_t>(imm);
 }
 
 void Emitter64::AND16_AX(uint16_t imm)
 {
-    cache->write<uint8_t>(0x66);
-    cache->write<uint8_t>(0x25);
-    cache->write<uint16_t>(imm);
+    block->write<uint8_t>(0x66);
+    block->write<uint8_t>(0x25);
+    block->write<uint16_t>(imm);
 }
 
 void Emitter64::AND16_REG(REG_64 source, REG_64 dest)
 {
-    cache->write<uint8_t>(0x66);
+    block->write<uint8_t>(0x66);
     rex_r_rm(source, dest);
-    cache->write<uint8_t>(0x21);
+    block->write<uint8_t>(0x21);
     modrm(0b11, source, dest);
 }
 
 void Emitter64::AND16_REG_IMM(uint16_t imm, REG_64 dest)
 {
-    cache->write<uint8_t>(0x66);
+    block->write<uint8_t>(0x66);
     rex_rm(dest);
-    cache->write<uint8_t>(0x81);
+    block->write<uint8_t>(0x81);
     modrm(0b11, 4, dest);
-    cache->write<uint16_t>(imm);
+    block->write<uint16_t>(imm);
 }
 
 void Emitter64::AND32_EAX(uint32_t imm)
 {
-    cache->write<uint8_t>(0x25);
-    cache->write<uint32_t>(imm);
+    block->write<uint8_t>(0x25);
+    block->write<uint32_t>(imm);
 }
 
 void Emitter64::AND32_REG(REG_64 source, REG_64 dest)
 {
     rex_r_rm(source, dest);
-    cache->write<uint8_t>(0x21);
+    block->write<uint8_t>(0x21);
     modrm(0b11, source, dest);
 }
 
 void Emitter64::AND32_REG_IMM(uint32_t imm, REG_64 dest)
 {
     rex_rm(dest);
-    cache->write<uint8_t>(0x81);
+    block->write<uint8_t>(0x81);
     modrm(0b11, 4, dest);
-    cache->write<uint32_t>(imm);
+    block->write<uint32_t>(imm);
 }
 
 void Emitter64::AND64_REG(REG_64 source, REG_64 dest)
 {
     rexw_r_rm(source, dest);
-    cache->write<uint8_t>(0x21);
+    block->write<uint8_t>(0x21);
     modrm(0b11, source, dest);
 }
 
 void Emitter64::CMOVCC16_REG(ConditionCode cc, REG_64 source, REG_64 dest)
 {
-    cache->write<uint8_t>(0x66);
+    block->write<uint8_t>(0x66);
     rex_r_rm(dest, source);
-    cache->write<uint8_t>(0x0F);
-    cache->write<uint8_t>((int)cc | 0x40);
+    block->write<uint8_t>(0x0F);
+    block->write<uint8_t>((int)cc | 0x40);
     modrm(0b11, dest, source);
 }
 
 void Emitter64::CMOVCC32_REG(ConditionCode cc, REG_64 source, REG_64 dest)
 {
     rex_r_rm(dest, source);
-    cache->write<uint8_t>(0x0F);
-    cache->write<uint8_t>((int)cc | 0x40);
+    block->write<uint8_t>(0x0F);
+    block->write<uint8_t>((int)cc | 0x40);
     modrm(0b11, dest, source);
 }
 
 void Emitter64::CMOVCC64_REG(ConditionCode cc, REG_64 source, REG_64 dest)
 {
     rexw_r_rm(dest, source);
-    cache->write<uint8_t>(0x0F);
-    cache->write<uint8_t>((int)cc | 0x40);
+    block->write<uint8_t>(0x0F);
+    block->write<uint8_t>((int)cc | 0x40);
     modrm(0b11, dest, source);
 }
 
 void Emitter64::CMOVCC16_MEM(ConditionCode cc, REG_64 source, REG_64 indir_dest, uint32_t offset)
 {
-    cache->write<uint8_t>(0x66);
-    cache->write<uint8_t>(0x0F);
-    cache->write<uint8_t>((int)cc | 0x40);
+    block->write<uint8_t>(0x66);
+    block->write<uint8_t>(0x0F);
+    block->write<uint8_t>((int)cc | 0x40);
 
     if ((indir_dest & 7) == 5 || offset)
     {
@@ -267,15 +265,15 @@ void Emitter64::CMOVCC16_MEM(ConditionCode cc, REG_64 source, REG_64 indir_dest,
     else
         modrm(0, indir_dest, source);
     if ((indir_dest & 7) == 4)
-        cache->write<uint8_t>(0x24);
+        block->write<uint8_t>(0x24);
     if ((indir_dest & 7) == 5 || offset)
-        cache->write<uint32_t>(offset);
+        block->write<uint32_t>(offset);
 }
 
 void Emitter64::CMOVCC32_MEM(ConditionCode cc, REG_64 source, REG_64 indir_dest, uint32_t offset)
 {
-    cache->write<uint8_t>(0x0F);
-    cache->write<uint8_t>((int)cc | 0x40);
+    block->write<uint8_t>(0x0F);
+    block->write<uint8_t>((int)cc | 0x40);
 
     if ((indir_dest & 7) == 5 || offset)
     {
@@ -284,16 +282,16 @@ void Emitter64::CMOVCC32_MEM(ConditionCode cc, REG_64 source, REG_64 indir_dest,
     else
         modrm(0, indir_dest, source);
     if ((indir_dest & 7) == 4)
-        cache->write<uint8_t>(0x24);
+        block->write<uint8_t>(0x24);
     if ((indir_dest & 7) == 5 || offset)
-        cache->write<uint32_t>(offset);
+        block->write<uint32_t>(offset);
 }
 
 void Emitter64::CMOVCC64_MEM(ConditionCode cc, REG_64 source, REG_64 indir_dest, uint32_t offset)
 {
     rexw_r_rm(indir_dest, source);
-    cache->write<uint8_t>(0x0F);
-    cache->write<uint8_t>((int)cc | 0x40);
+    block->write<uint8_t>(0x0F);
+    block->write<uint8_t>((int)cc | 0x40);
 
     if ((indir_dest & 7) == 5 || offset)
     {
@@ -302,9 +300,9 @@ void Emitter64::CMOVCC64_MEM(ConditionCode cc, REG_64 source, REG_64 indir_dest,
     else
         modrm(0, indir_dest, source);
     if ((indir_dest & 7) == 4)
-        cache->write<uint8_t>(0x24);
+        block->write<uint8_t>(0x24);
     if ((indir_dest & 7) == 5 || offset)
-        cache->write<uint32_t>(offset);
+        block->write<uint32_t>(offset);
 }
 
 void Emitter64::CMP8_REG(REG_64 op2, REG_64 op1)
@@ -313,225 +311,225 @@ void Emitter64::CMP8_REG(REG_64 op2, REG_64 op1)
 
     // FIXME: I still don't know anything about encoding these instructions, woooo
     if (!(op2 & 0x8) && !(op1 & 0x8))
-        cache->write<uint8_t>(0x40);
+        block->write<uint8_t>(0x40);
 
-    cache->write<uint8_t>(0x38);
+    block->write<uint8_t>(0x38);
     modrm(0b11, op2, op1);
 }
 
 void Emitter64::CMP16_IMM(uint16_t imm, REG_64 op)
 {
-    cache->write<uint8_t>(0x66);
+    block->write<uint8_t>(0x66);
     rex_rm(op);
-    cache->write<uint8_t>(0x81);
+    block->write<uint8_t>(0x81);
     modrm(0b11, 7, op);
-    cache->write<uint16_t>(imm);
+    block->write<uint16_t>(imm);
 }
 
 void Emitter64::CMP16_REG(REG_64 op2, REG_64 op1)
 {
-    cache->write<uint8_t>(0x66);
+    block->write<uint8_t>(0x66);
     rex_r_rm(op2, op1);
-    cache->write<uint8_t>(0x39);
+    block->write<uint8_t>(0x39);
     modrm(0b11, op2, op1);
 }
 
 void Emitter64::CMP32_IMM(uint32_t imm, REG_64 op)
 {
     rex_rm(op);
-    cache->write<uint8_t>(0x81);
+    block->write<uint8_t>(0x81);
     modrm(0b11, 7, op);
-    cache->write<uint32_t>(imm);
+    block->write<uint32_t>(imm);
 }
 
 void Emitter64::CMP32_REG(REG_64 op2, REG_64 op1)
 {
     rex_r_rm(op2, op1);
-    cache->write<uint8_t>(0x39);
+    block->write<uint8_t>(0x39);
     modrm(0b11, op2, op1);
 }
 
 void Emitter64::CMP32_EAX(uint32_t imm)
 {
-    cache->write<uint8_t>(0x3D);
-    cache->write<uint32_t>(imm);
+    block->write<uint8_t>(0x3D);
+    block->write<uint32_t>(imm);
 }
 
 void Emitter64::CMP64_IMM(uint32_t imm, REG_64 op)
 {
     rexw_rm(op);
-    cache->write<uint8_t>(0x81);
+    block->write<uint8_t>(0x81);
     modrm(0b11, 7, op);
-    cache->write<uint32_t>(imm);
+    block->write<uint32_t>(imm);
 }
 
 void Emitter64::CMP64_REG(REG_64 op2, REG_64 op1)
 {
     rexw_r_rm(op2, op1);
-    cache->write<uint8_t>(0x39);
+    block->write<uint8_t>(0x39);
     modrm(0b11, op2, op1);
 }
 
 void Emitter64::CWD()
 {
-    cache->write<uint8_t>(0x66);
-    cache->write<uint8_t>(0x99);
+    block->write<uint8_t>(0x66);
+    block->write<uint8_t>(0x99);
 }
 
 void Emitter64::CDQ()
 {
-    cache->write<uint8_t>(0x99);
+    block->write<uint8_t>(0x99);
 }
 
 void Emitter64::CQO()
 {
-    cache->write<uint8_t>(0x48);
-    cache->write<uint8_t>(0x99);
+    block->write<uint8_t>(0x48);
+    block->write<uint8_t>(0x99);
 }
 
 void Emitter64::DEC8(REG_64 dest)
 {
     rex_rm(dest);
-    cache->write<uint8_t>(0xFE);
+    block->write<uint8_t>(0xFE);
     modrm(0b11, 1, dest);
 }
 
 void Emitter64::DEC16(REG_64 dest)
 {
-    cache->write<uint8_t>(0x66);
+    block->write<uint8_t>(0x66);
     rex_rm(dest);
-    cache->write<uint8_t>(0xFF);
+    block->write<uint8_t>(0xFF);
     modrm(0b11, 1, dest);
 }
 
 void Emitter64::DEC32(REG_64 dest)
 {
     rex_rm(dest);
-    cache->write<uint8_t>(0xFF);
+    block->write<uint8_t>(0xFF);
     modrm(0b11, 1, dest);
 }
 
 void Emitter64::DEC64(REG_64 dest)
 {
     rexw_rm(dest);
-    cache->write<uint8_t>(0xFF);
+    block->write<uint8_t>(0xFF);
     modrm(0b11, 1, dest);
 }
 
 void Emitter64::DIV32(REG_64 dest)
 {
     rex_rm(dest);
-    cache->write<uint8_t>(0xF7);
+    block->write<uint8_t>(0xF7);
     modrm(0b11, 6, dest);
 }
 
 void Emitter64::IDIV32(REG_64 dest)
 {
     rex_rm(dest);
-    cache->write<uint8_t>(0xF7);
+    block->write<uint8_t>(0xF7);
     modrm(0b11, 7, dest);
 }
 
 void Emitter64::MUL32(REG_64 dest)
 {
     rex_rm(dest);
-    cache->write<uint8_t>(0xF7);
+    block->write<uint8_t>(0xF7);
     modrm(0b11, 4, dest);
 }
 
 void Emitter64::IMUL32(REG_64 dest)
 {
     rex_rm(dest);
-    cache->write<uint8_t>(0xF7);
+    block->write<uint8_t>(0xF7);
     modrm(0b11, 5, dest);
 }
 
 void Emitter64::NOT16(REG_64 dest)
 {
-    cache->write<uint8_t>(0x66);
+    block->write<uint8_t>(0x66);
     rex_rm(dest);
-    cache->write<uint8_t>(0xF7);
+    block->write<uint8_t>(0xF7);
     modrm(0b11, 2, dest);
 }
 
 void Emitter64::NOT32(REG_64 dest)
 {
     rex_rm(dest);
-    cache->write<uint8_t>(0xF7);
+    block->write<uint8_t>(0xF7);
     modrm(0b11, 2, dest);
 }
 
 void Emitter64::NOT64(REG_64 dest)
 {
     rexw_rm(dest);
-    cache->write<uint8_t>(0xF7);
+    block->write<uint8_t>(0xF7);
     modrm(0b11, 2, dest);
 }
 
 void Emitter64::NEG16(REG_64 dest)
 {
-    cache->write<uint8_t>(0x66);
+    block->write<uint8_t>(0x66);
     rex_rm(dest);
-    cache->write<uint8_t>(0xF7);
+    block->write<uint8_t>(0xF7);
     modrm(0b11, 3, dest);
 }
 
 void Emitter64::NEG32(REG_64 dest)
 {
     rex_rm(dest);
-    cache->write<uint8_t>(0xF7);
+    block->write<uint8_t>(0xF7);
     modrm(0b11, 3, dest);
 }
 
 void Emitter64::NEG64(REG_64 dest)
 {
     rexw_rm(dest);
-    cache->write<uint8_t>(0xF7);
+    block->write<uint8_t>(0xF7);
     modrm(0b11, 3, dest);
 }
 
 void Emitter64::OR16_REG(REG_64 source, REG_64 dest)
 {
-    cache->write<uint8_t>(0x66);
+    block->write<uint8_t>(0x66);
     rex_r_rm(source, dest);
-    cache->write<uint8_t>(0x09);
+    block->write<uint8_t>(0x09);
     modrm(0b11, source, dest);
 }
 
 void Emitter64::OR16_REG_IMM(uint16_t imm, REG_64 dest)
 {
-    cache->write<uint8_t>(0x66);
+    block->write<uint8_t>(0x66);
     rex_rm(dest);
-    cache->write<uint8_t>(0x81);
+    block->write<uint8_t>(0x81);
     modrm(0b11, 1, dest);
-    cache->write<uint16_t>(imm);
+    block->write<uint16_t>(imm);
 }
 
 void Emitter64::OR32_REG(REG_64 source, REG_64 dest)
 {
     rex_r_rm(source, dest);
-    cache->write<uint8_t>(0x09);
+    block->write<uint8_t>(0x09);
     modrm(0b11, source, dest);
 }
 
 void Emitter64::OR32_REG_IMM(uint32_t imm, REG_64 dest)
 {
     rex_rm(dest);
-    cache->write<uint8_t>(0x81);
+    block->write<uint8_t>(0x81);
     modrm(0b11, 1, dest);
-    cache->write<uint32_t>(imm);
+    block->write<uint32_t>(imm);
 }
 
 void Emitter64::OR32_EAX(uint32_t imm)
 {
-    cache->write<uint8_t>(0x0D);
-    cache->write<uint32_t>(imm);
+    block->write<uint8_t>(0x0D);
+    block->write<uint32_t>(imm);
 }
 
 void Emitter64::OR64_REG(REG_64 source, REG_64 dest)
 {
     rexw_r_rm(source, dest);
-    cache->write<uint8_t>(0x09);
+    block->write<uint8_t>(0x09);
     modrm(0b11, source, dest);
 }
 
@@ -541,18 +539,18 @@ void Emitter64::SETCC_REG(ConditionCode cc, REG_64 dest)
 
     // FIXME: fix encoding so we don't explicitly write 0x40 here :D
     if (!(dest & 0x8))
-        cache->write<uint8_t>(0x40);
+        block->write<uint8_t>(0x40);
 
-    cache->write<uint8_t>(0x0F);
-    cache->write<uint8_t>((int)cc | 0x90);
+    block->write<uint8_t>(0x0F);
+    block->write<uint8_t>((int)cc | 0x90);
     modrm(0b11, 0, dest);
 }
 
 void Emitter64::SETCC_MEM(ConditionCode cc, REG_64 indir_dest, uint32_t offset)
 {
     rex_rm(indir_dest);
-    cache->write<uint8_t>(0x0F);
-    cache->write<uint8_t>((int)cc | 0x90);
+    block->write<uint8_t>(0x0F);
+    block->write<uint8_t>((int)cc | 0x90);
 
     if ((indir_dest & 7) == 5 || offset)
     {
@@ -561,300 +559,300 @@ void Emitter64::SETCC_MEM(ConditionCode cc, REG_64 indir_dest, uint32_t offset)
     else
         modrm(0, 0, indir_dest);
     if ((indir_dest & 7) == 4)
-        cache->write<uint8_t>(0x24);
+        block->write<uint8_t>(0x24);
     if ((indir_dest & 7) == 5 || offset)
-        cache->write<uint32_t>(offset);
+        block->write<uint32_t>(offset);
 }
 
 void Emitter64::SHL8_REG_1(REG_64 dest)
 {
     rex_rm(dest);
-    cache->write<uint8_t>(0xD0);
+    block->write<uint8_t>(0xD0);
     modrm(0b11, 4, dest);
 }
 
 void Emitter64::SHL16_REG_1(REG_64 dest)
 {
-    cache->write<uint8_t>(0x66);
+    block->write<uint8_t>(0x66);
     rex_rm(dest);
-    cache->write<uint8_t>(0xD1);
+    block->write<uint8_t>(0xD1);
     modrm(0b11, 4, dest);
 }
 
 void Emitter64::SHL16_CL(REG_64 dest)
 {
-    cache->write<uint8_t>(0x66);
+    block->write<uint8_t>(0x66);
     rex_rm(dest);
-    cache->write<uint8_t>(0xD3);
+    block->write<uint8_t>(0xD3);
     modrm(0b11, 4, dest);
 }
 
 void Emitter64::SHL16_REG_IMM(uint8_t shift, REG_64 dest)
 {
-    cache->write<uint8_t>(0x66);
+    block->write<uint8_t>(0x66);
     rex_rm(dest);
-    cache->write<uint8_t>(0xC1);
+    block->write<uint8_t>(0xC1);
     modrm(0b11, 4, dest);
-    cache->write<uint8_t>(shift);
+    block->write<uint8_t>(shift);
 }
 
 void Emitter64::SHL32_CL(REG_64 dest)
 {
     rex_rm(dest);
-    cache->write<uint8_t>(0xD3);
+    block->write<uint8_t>(0xD3);
     modrm(0b11, 4, dest);
 }
 
 void Emitter64::SHL32_REG_IMM(uint8_t shift, REG_64 dest)
 {
     rex_rm(dest);
-    cache->write<uint8_t>(0xC1);
+    block->write<uint8_t>(0xC1);
     modrm(0b11, 4, dest);
-    cache->write<uint8_t>(shift);
+    block->write<uint8_t>(shift);
 }
 
 void Emitter64::SHL64_CL(REG_64 dest)
 {
     rexw_rm(dest);
-    cache->write<uint8_t>(0xD3);
+    block->write<uint8_t>(0xD3);
     modrm(0b11, 4, dest);
 }
 
 void Emitter64::SHL64_REG_IMM(uint8_t shift, REG_64 dest)
 {
     rexw_rm(dest);
-    cache->write<uint8_t>(0xC1);
+    block->write<uint8_t>(0xC1);
     modrm(0b11, 4, dest);
-    cache->write<uint8_t>(shift);
+    block->write<uint8_t>(shift);
 }
 
 void Emitter64::SHR16_CL(REG_64 dest)
 {
-    cache->write<uint8_t>(0x66);
+    block->write<uint8_t>(0x66);
     rex_rm(dest);
-    cache->write<uint8_t>(0xD3);
+    block->write<uint8_t>(0xD3);
     modrm(0b11, 5, dest);
 }
 
 void Emitter64::SHR16_REG_IMM(uint8_t shift, REG_64 dest)
 {
-    cache->write<uint8_t>(0x66);
+    block->write<uint8_t>(0x66);
     rex_rm(dest);
-    cache->write<uint8_t>(0xC1);
+    block->write<uint8_t>(0xC1);
     modrm(0b11, 5, dest);
-    cache->write<uint8_t>(shift);
+    block->write<uint8_t>(shift);
 }
 
 void Emitter64::SHR32_CL(REG_64 dest)
 {
     rex_rm(dest);
-    cache->write<uint8_t>(0xD3);
+    block->write<uint8_t>(0xD3);
     modrm(0b11, 5, dest);
 }
 
 void Emitter64::SHR32_REG_IMM(uint8_t shift, REG_64 dest)
 {
     rex_rm(dest);
-    cache->write<uint8_t>(0xC1);
+    block->write<uint8_t>(0xC1);
     modrm(0b11, 5, dest);
-    cache->write<uint8_t>(shift);
+    block->write<uint8_t>(shift);
 }
 
 void Emitter64::SHR64_CL(REG_64 dest)
 {
     rexw_rm(dest);
-    cache->write<uint8_t>(0xD3);
+    block->write<uint8_t>(0xD3);
     modrm(0b11, 5, dest);
 }
 
 void Emitter64::SHR64_REG_IMM(uint8_t shift, REG_64 dest)
 {
     rexw_rm(dest);
-    cache->write<uint8_t>(0xC1);
+    block->write<uint8_t>(0xC1);
     modrm(0b11, 5, dest);
-    cache->write<uint8_t>(shift);
+    block->write<uint8_t>(shift);
 }
 
 void Emitter64::SAR16_CL(REG_64 dest)
 {
-    cache->write<uint8_t>(0x66);
+    block->write<uint8_t>(0x66);
     rex_rm(dest);
-    cache->write<uint8_t>(0xD3);
+    block->write<uint8_t>(0xD3);
     modrm(0b11, 7, dest);
 }
 
 void Emitter64::SAR16_REG_IMM(uint8_t shift, REG_64 dest)
 {
-    cache->write<uint8_t>(0x66);
+    block->write<uint8_t>(0x66);
     rex_rm(dest);
-    cache->write<uint8_t>(0xC1);
+    block->write<uint8_t>(0xC1);
     modrm(0b11, 7, dest);
-    cache->write<uint8_t>(shift);
+    block->write<uint8_t>(shift);
 }
 
 void Emitter64::SAR32_CL(REG_64 dest)
 {
     rex_rm(dest);
-    cache->write<uint8_t>(0xD3);
+    block->write<uint8_t>(0xD3);
     modrm(0b11, 7, dest);
 }
 
 void Emitter64::SAR32_REG_IMM(uint8_t shift, REG_64 dest)
 {
     rex_rm(dest);
-    cache->write<uint8_t>(0xC1);
+    block->write<uint8_t>(0xC1);
     modrm(0b11, 7, dest);
-    cache->write<uint8_t>(shift);
+    block->write<uint8_t>(shift);
 }
 
 void Emitter64::SAR64_CL(REG_64 dest)
 {
     rexw_rm(dest);
-    cache->write<uint8_t>(0xD3);
+    block->write<uint8_t>(0xD3);
     modrm(0b11, 7, dest);
 }
 
 void Emitter64::SAR64_REG_IMM(uint8_t shift, REG_64 dest)
 {
     rexw_rm(dest);
-    cache->write<uint8_t>(0xC1);
+    block->write<uint8_t>(0xC1);
     modrm(0b11, 7, dest);
-    cache->write<uint8_t>(shift);
+    block->write<uint8_t>(shift);
 }
 
 void Emitter64::SUB16_REG_IMM(uint16_t imm, REG_64 dest)
 {
-    cache->write<uint8_t>(0x66);
+    block->write<uint8_t>(0x66);
     rex_rm(dest);
-    cache->write<uint8_t>(0x81);
+    block->write<uint8_t>(0x81);
     modrm(0b11, 5, dest);
-    cache->write<uint16_t>(imm);
+    block->write<uint16_t>(imm);
 }
 
 void Emitter64::SUB32_REG(REG_64 source, REG_64 dest)
 {
     rex_r_rm(source, dest);
-    cache->write<uint8_t>(0x29);
+    block->write<uint8_t>(0x29);
     modrm(0b11, source, dest);
 }
 
 void Emitter64::SUB64_REG(REG_64 source, REG_64 dest)
 {
     rexw_r_rm(source, dest);
-    cache->write<uint8_t>(0x29);
+    block->write<uint8_t>(0x29);
     modrm(0b11, source, dest);
 }
 
 void Emitter64::SUB64_REG_IMM(uint32_t imm, REG_64 dest)
 {
     rexw_rm(dest);
-    cache->write<uint8_t>(0x81);
+    block->write<uint8_t>(0x81);
     modrm(0b11, 5, dest);
-    cache->write<uint32_t>(imm);
+    block->write<uint32_t>(imm);
 }
 
 void Emitter64::TEST8_REG(REG_64 op2, REG_64 op1)
 {
     rex_r_rm(op2, op1);
-    cache->write<uint8_t>(0x84);
+    block->write<uint8_t>(0x84);
     modrm(0b11, op2, op1);
 }
 
 void Emitter64::TEST8_REG_IMM(uint8_t imm, REG_64 op1)
 {
     rex_r_rm((REG_64)0, op1);
-    cache->write<uint8_t>(0xF6);
+    block->write<uint8_t>(0xF6);
     modrm(0b11, 0, op1);
-    cache->write<uint8_t>(imm);
+    block->write<uint8_t>(imm);
 }
 
 void Emitter64::TEST16_REG(REG_64 op2, REG_64 op1)
 {
-    cache->write<uint8_t>(0x66);
+    block->write<uint8_t>(0x66);
     rex_r_rm(op2, op1);
-    cache->write<uint8_t>(0x85);
+    block->write<uint8_t>(0x85);
     modrm(0b11, op2, op1);
 }
 
 void Emitter64::TEST16_REG_IMM(uint16_t imm, REG_64 op1)
 {
-    cache->write<uint8_t>(0x66);
+    block->write<uint8_t>(0x66);
     rex_r_rm((REG_64)0, op1);
-    cache->write<uint8_t>(0xF7);
+    block->write<uint8_t>(0xF7);
     modrm(0b11, 0, op1);
-    cache->write<uint16_t>(imm);
+    block->write<uint16_t>(imm);
 }
 
 void Emitter64::TEST32_EAX(uint32_t imm)
 {
-    cache->write<uint8_t>(0xA9);
-    cache->write<uint32_t>(imm);
+    block->write<uint8_t>(0xA9);
+    block->write<uint32_t>(imm);
 }
 
 void Emitter64::TEST32_REG(REG_64 op2, REG_64 op1)
 {
     rex_r_rm(op2, op1);
-    cache->write<uint8_t>(0x85);
+    block->write<uint8_t>(0x85);
     modrm(0b11, op2, op1);
 }
 
 void Emitter64::TEST32_REG_IMM(uint32_t imm, REG_64 op1)
 {
     rex_r_rm((REG_64)0, op1);
-    cache->write<uint8_t>(0xF7);
+    block->write<uint8_t>(0xF7);
     modrm(0b11, 0, op1);
-    cache->write<uint32_t>(imm);
+    block->write<uint32_t>(imm);
 }
 
 void Emitter64::TEST64_REG(REG_64 op2, REG_64 op1)
 {
     rexw_r_rm(op2, op1);
-    cache->write<uint8_t>(0x85);
+    block->write<uint8_t>(0x85);
     modrm(0b11, op2, op1);
 }
 
 void Emitter64::TEST64_REG_IMM(uint32_t imm, REG_64 op1)
 {
     rexw_r_rm((REG_64)0, op1);
-    cache->write<uint8_t>(0xF7);
+    block->write<uint8_t>(0xF7);
     modrm(0b11, 0, op1);
-    cache->write<uint32_t>(imm);
+    block->write<uint32_t>(imm);
 }
 
 void Emitter64::XOR16_REG(REG_64 source, REG_64 dest)
 {
-    cache->write<uint8_t>(0x66);
+    block->write<uint8_t>(0x66);
     rex_r_rm(source, dest);
-    cache->write<uint8_t>(0x31);
+    block->write<uint8_t>(0x31);
     modrm(0b11, source, dest);
 }
 
 void Emitter64::XOR16_REG_IMM(uint16_t imm, REG_64 dest)
 {
-    cache->write<uint8_t>(0x66);
+    block->write<uint8_t>(0x66);
     rex_rm(dest);
-    cache->write<uint8_t>(0x81);
+    block->write<uint8_t>(0x81);
     modrm(0b11, 6, dest);
-    cache->write<uint16_t>(imm);
+    block->write<uint16_t>(imm);
 }
 
 void Emitter64::XOR32_REG(REG_64 source, REG_64 dest)
 {
     rex_r_rm(source, dest);
-    cache->write<uint8_t>(0x31);
+    block->write<uint8_t>(0x31);
     modrm(0b11, source, dest);
 }
 
 void Emitter64::XOR32_EAX(uint32_t imm)
 {
-    cache->write<uint8_t>(0x35);
-    cache->write<uint32_t>(imm);
+    block->write<uint8_t>(0x35);
+    block->write<uint32_t>(imm);
 }
 
 void Emitter64::XOR64_REG(REG_64 source, REG_64 dest)
 {
     rexw_r_rm(source, dest);
-    cache->write<uint8_t>(0x31);
+    block->write<uint8_t>(0x31);
     modrm(0b11, source, dest);
 }
 
@@ -863,11 +861,11 @@ void Emitter64::LEA32_M(REG_64 source, REG_64 dest, uint32_t offset, uint32_t sh
     offset <<= shift;
 
     rex_r_rm(dest, source);
-    cache->write<uint8_t>(0x8D);
+    block->write<uint8_t>(0x8D);
     modrm(0b10, dest, source);
     if ((source & 7) == 4)
-        cache->write<uint8_t>(0x24);
-    cache->write<uint32_t>(offset);
+        block->write<uint8_t>(0x24);
+    block->write<uint32_t>(offset);
 }
 
 void Emitter64::LEA32_REG(REG_64 source, REG_64 source2, REG_64 dest, uint32_t offset, uint32_t shift)
@@ -878,11 +876,11 @@ void Emitter64::LEA32_REG(REG_64 source, REG_64 source2, REG_64 dest, uint32_t o
     if (dest & 0x8) rex += 0x4;
     if (source & 0x8) rex += 0x2;
     if (source2 & 0x8) rex += 0x1;
-    cache->write<uint8_t>(rex);
-    cache->write<uint8_t>(0x8D);
+    block->write<uint8_t>(rex);
+    block->write<uint8_t>(0x8D);
     modrm(0b10, dest, 4);
     modrm(0b00, source, source2);
-    cache->write<uint32_t>(offset);
+    block->write<uint32_t>(offset);
 }
 
 void Emitter64::LEA64_M(REG_64 source, REG_64 dest, uint32_t offset, uint32_t shift)
@@ -890,11 +888,11 @@ void Emitter64::LEA64_M(REG_64 source, REG_64 dest, uint32_t offset, uint32_t sh
     offset <<= shift;
 
     rexw_r_rm(dest, source);
-    cache->write<uint8_t>(0x8D);
+    block->write<uint8_t>(0x8D);
     modrm(0b10, dest, source);
     if ((source & 7) == 4)
-        cache->write<uint8_t>(0x24);
-    cache->write<uint32_t>(offset);
+        block->write<uint8_t>(0x24);
+    block->write<uint32_t>(offset);
 }
 
 void Emitter64::LEA64_REG(REG_64 source, REG_64 source2, REG_64 dest, uint32_t offset, uint32_t shift)
@@ -905,11 +903,11 @@ void Emitter64::LEA64_REG(REG_64 source, REG_64 source2, REG_64 dest, uint32_t o
     if (dest & 0x8) rex += 0x4;
     if (source & 0x8) rex += 0x2;
     if (source2 & 0x8) rex += 0x1;
-    cache->write<uint8_t>(rex);
-    cache->write<uint8_t>(0x8D);
+    block->write<uint8_t>(rex);
+    block->write<uint8_t>(0x8D);
     modrm(0b10, dest, 4);
     modrm(0b00, source, source2);
-    cache->write<uint32_t>(offset);
+    block->write<uint32_t>(offset);
 }
 
 void Emitter64::MOV8_REG(REG_64 source, REG_64 dest)
@@ -918,9 +916,9 @@ void Emitter64::MOV8_REG(REG_64 source, REG_64 dest)
 
     // FIXME: I still don't know anything about encoding these instructions, woooo
     if (!(dest & 0x8) && !(source & 0x8))
-        cache->write<uint8_t>(0x40);
+        block->write<uint8_t>(0x40);
 
-    cache->write<uint8_t>(0x88);
+    block->write<uint8_t>(0x88);
     modrm(0b11, source, dest);
 }
 
@@ -930,16 +928,16 @@ void Emitter64::MOV8_REG_IMM(uint8_t imm, REG_64 dest)
 
     // FIXME: I still don't know anything about encoding these instructions, woooo
     if (!(dest & 0x8))
-        cache->write<uint8_t>(0x40);
+        block->write<uint8_t>(0x40);
 
-    cache->write<uint8_t>(0xB0 + (dest & 0x7));
-    cache->write<uint8_t>(imm);
+    block->write<uint8_t>(0xB0 + (dest & 0x7));
+    block->write<uint8_t>(imm);
 }
 
 void Emitter64::MOV8_TO_MEM(REG_64 source, REG_64 indir_dest, uint32_t offset)
 {
     rex_r_rm(source, indir_dest);
-    cache->write<uint8_t>(0x88);
+    block->write<uint8_t>(0x88);
 
     if ((indir_dest & 7) == 5 || offset)
     {
@@ -948,15 +946,15 @@ void Emitter64::MOV8_TO_MEM(REG_64 source, REG_64 indir_dest, uint32_t offset)
     else
         modrm(0, source, indir_dest);
     if ((indir_dest & 7) == 4)
-        cache->write<uint8_t>(0x24);
+        block->write<uint8_t>(0x24);
     if ((indir_dest & 7) == 5 || offset)
-        cache->write<uint32_t>(offset);
+        block->write<uint32_t>(offset);
 }
 
 void Emitter64::MOV8_FROM_MEM(REG_64 indir_source, REG_64 dest, uint32_t offset)
 {
     rex_r_rm(dest, indir_source);
-    cache->write<uint8_t>(0x8A);
+    block->write<uint8_t>(0x8A);
 
     if ((indir_source & 7) == 5 || offset)
     {
@@ -965,50 +963,50 @@ void Emitter64::MOV8_FROM_MEM(REG_64 indir_source, REG_64 dest, uint32_t offset)
     else
         modrm(0, dest, indir_source);
     if ((indir_source & 7) == 4)
-        cache->write<uint8_t>(0x24);
+        block->write<uint8_t>(0x24);
     if ((indir_source & 7) == 5 || offset)
-        cache->write<uint32_t>(offset);
+        block->write<uint32_t>(offset);
 }
 
 void Emitter64::MOV8_IMM_MEM(uint8_t imm, REG_64 indir_dest, uint32_t offset)
 {
     rex_rm(indir_dest);
-    cache->write<uint8_t>(0xC6);
+    block->write<uint8_t>(0xC6);
     if ((indir_dest & 7) == 5 || offset != 0)
     {
         modrm(0b10, 0, indir_dest);
-        cache->write<uint32_t>(offset);
+        block->write<uint32_t>(offset);
     }
     else
     {
         modrm(0, 0, indir_dest);
     }
     if ((indir_dest & 7) == 4)
-        cache->write<uint8_t>(0x24);
-    cache->write<uint8_t>(imm);
+        block->write<uint8_t>(0x24);
+    block->write<uint8_t>(imm);
 }
 
 void Emitter64::MOV16_REG(REG_64 source, REG_64 dest)
 {
-    cache->write<uint8_t>(0x66);
+    block->write<uint8_t>(0x66);
     rex_r_rm(source, dest);
-    cache->write<uint8_t>(0x89);
+    block->write<uint8_t>(0x89);
     modrm(0b11, source, dest);
 }
 
 void Emitter64::MOV16_REG_IMM(uint16_t imm, REG_64 dest)
 {
-    cache->write<uint8_t>(0x66);
+    block->write<uint8_t>(0x66);
     rex_rm(dest);
-    cache->write<uint8_t>(0xB8 + (dest & 0x7));
-    cache->write<uint16_t>(imm);
+    block->write<uint8_t>(0xB8 + (dest & 0x7));
+    block->write<uint16_t>(imm);
 }
 
 void Emitter64::MOV16_TO_MEM(REG_64 source, REG_64 indir_dest, uint32_t offset)
 {
-    cache->write<uint8_t>(0x66);
+    block->write<uint8_t>(0x66);
     rex_r_rm(source, indir_dest);
-    cache->write<uint8_t>(0x89);
+    block->write<uint8_t>(0x89);
 
     if ((indir_dest & 7) == 5 || offset)
     {
@@ -1017,16 +1015,16 @@ void Emitter64::MOV16_TO_MEM(REG_64 source, REG_64 indir_dest, uint32_t offset)
     else
         modrm(0, source, indir_dest);
     if ((indir_dest & 7) == 4)
-        cache->write<uint8_t>(0x24);
+        block->write<uint8_t>(0x24);
     if ((indir_dest & 7) == 5 || offset)
-        cache->write<uint32_t>(offset);
+        block->write<uint32_t>(offset);
 }
 
 void Emitter64::MOV16_FROM_MEM(REG_64 indir_source, REG_64 dest, uint32_t offset)
 {
-    cache->write<uint8_t>(0x66);
+    block->write<uint8_t>(0x66);
     rex_r_rm(dest, indir_source);
-    cache->write<uint8_t>(0x8B);
+    block->write<uint8_t>(0x8B);
 
     if ((indir_source & 7) == 5 || offset)
     {
@@ -1035,66 +1033,66 @@ void Emitter64::MOV16_FROM_MEM(REG_64 indir_source, REG_64 dest, uint32_t offset
     else
         modrm(0, dest, indir_source);
     if ((indir_source & 7) == 4)
-        cache->write<uint8_t>(0x24);
+        block->write<uint8_t>(0x24);
     if ((indir_source & 7) == 5 || offset)
-        cache->write<uint32_t>(offset);
+        block->write<uint32_t>(offset);
 }
 
 void Emitter64::MOV16_IMM_MEM(uint16_t imm, REG_64 indir_dest, uint32_t offset)
 {
-    cache->write<uint8_t>(0x66);
+    block->write<uint8_t>(0x66);
     rex_rm(indir_dest);
-    cache->write<uint8_t>(0xC7);
+    block->write<uint8_t>(0xC7);
     if ((indir_dest & 7) == 5 || offset != 0)
     {
         modrm(0b10, 0, indir_dest);
-        cache->write<uint32_t>(offset);
+        block->write<uint32_t>(offset);
     }
     else
     {
         modrm(0, 0, indir_dest);
     }
     if ((indir_dest & 7) == 4)
-        cache->write<uint8_t>(0x24);
-    cache->write<uint16_t>(imm);
+        block->write<uint8_t>(0x24);
+    block->write<uint16_t>(imm);
 }
 
 void Emitter64::MOV32_REG(REG_64 source, REG_64 dest)
 {
     rex_r_rm(source, dest);
-    cache->write<uint8_t>(0x89);
+    block->write<uint8_t>(0x89);
     modrm(0b11, source, dest);
 }
 
 void Emitter64::MOV32_REG_IMM(uint32_t imm, REG_64 dest)
 {
     rex_rm(dest);
-    cache->write<uint8_t>(0xB8 + (dest & 0x7));
-    cache->write<uint32_t>(imm);
+    block->write<uint8_t>(0xB8 + (dest & 0x7));
+    block->write<uint32_t>(imm);
 }
 
 void Emitter64::MOV32_IMM_MEM(uint32_t imm, REG_64 indir_dest, uint32_t offset)
 {
     rex_rm(indir_dest);
-    cache->write<uint8_t>(0xC7);
+    block->write<uint8_t>(0xC7);
     if ((indir_dest & 7) == 5 || offset != 0)
     {
         modrm(0b10, 0, indir_dest);
-        cache->write<uint32_t>(offset);
+        block->write<uint32_t>(offset);
     }
     else
     {
         modrm(0, 0, indir_dest);
     }
     if ((indir_dest & 7) == 4)
-        cache->write<uint8_t>(0x24);
-    cache->write<uint32_t>(imm);
+        block->write<uint8_t>(0x24);
+    block->write<uint32_t>(imm);
 }
 
 void Emitter64::MOV32_FROM_MEM(REG_64 indir_source, REG_64 dest, uint32_t offset)
 {
     rex_r_rm(dest, indir_source);
-    cache->write<uint8_t>(0x8B);
+    block->write<uint8_t>(0x8B);
 
     if ((indir_source & 7) == 5 || offset)
     {
@@ -1103,15 +1101,15 @@ void Emitter64::MOV32_FROM_MEM(REG_64 indir_source, REG_64 dest, uint32_t offset
     else
         modrm(0, dest, indir_source);
     if ((indir_source & 7) == 4)
-        cache->write<uint8_t>(0x24);
+        block->write<uint8_t>(0x24);
     if ((indir_source & 7) == 5 || offset)
-        cache->write<uint32_t>(offset);
+        block->write<uint32_t>(offset);
 }
 
 void Emitter64::MOV32_TO_MEM(REG_64 source, REG_64 indir_dest, uint32_t offset)
 {
     rex_r_rm(source, indir_dest);
-    cache->write<uint8_t>(0x89);
+    block->write<uint8_t>(0x89);
 
     if ((indir_dest & 7) == 5 || offset)
     {
@@ -1120,47 +1118,47 @@ void Emitter64::MOV32_TO_MEM(REG_64 source, REG_64 indir_dest, uint32_t offset)
     else
         modrm(0, source, indir_dest);
     if ((indir_dest & 7) == 4)
-        cache->write<uint8_t>(0x24);
+        block->write<uint8_t>(0x24);
     if ((indir_dest & 7) == 5 || offset)
-        cache->write<uint32_t>(offset);
+        block->write<uint32_t>(offset);
 }
 
 void Emitter64::MOV32SX_IMM_MEM(uint32_t imm, REG_64 indir_dest, uint32_t offset)
 {
     rexw_rm(indir_dest);
-    cache->write<uint8_t>(0xC7);
+    block->write<uint8_t>(0xC7);
     if ((indir_dest & 7) == 5 || offset != 0)
     {
         modrm(0b10, 0, indir_dest);
-        cache->write<uint32_t>(offset);
+        block->write<uint32_t>(offset);
     }
     else
     {
         modrm(0, 0, indir_dest);
     }
     if ((indir_dest & 7) == 4)
-        cache->write<uint8_t>(0x24);
-    cache->write<uint32_t>(imm);
+        block->write<uint8_t>(0x24);
+    block->write<uint32_t>(imm);
 }
 
 void Emitter64::MOV64_MR(REG_64 source, REG_64 dest)
 {
     rexw_r_rm(source, dest);
-    cache->write<uint8_t>(0x89);
+    block->write<uint8_t>(0x89);
     modrm(0b11, source, dest);
 }
 
 void Emitter64::MOV64_OI(uint64_t imm, REG_64 dest)
 {
     rexw_rm(dest);
-    cache->write<uint8_t>(0xB8 + (dest & 0x7));
-    cache->write<uint64_t>(imm);
+    block->write<uint8_t>(0xB8 + (dest & 0x7));
+    block->write<uint64_t>(imm);
 }
 
 void Emitter64::MOV64_FROM_MEM(REG_64 indir_source, REG_64 dest, uint32_t offset)
 {
     rexw_r_rm(dest, indir_source);
-    cache->write<uint8_t>(0x8B);
+    block->write<uint8_t>(0x8B);
 
     if ((indir_source & 7) == 5 || offset)
     {
@@ -1169,15 +1167,15 @@ void Emitter64::MOV64_FROM_MEM(REG_64 indir_source, REG_64 dest, uint32_t offset
     else
         modrm(0, dest, indir_source);
     if ((indir_source & 7) == 4)
-        cache->write<uint8_t>(0x24);
+        block->write<uint8_t>(0x24);
     if ((indir_source & 7) == 5 || offset)
-        cache->write<uint32_t>(offset);
+        block->write<uint32_t>(offset);
 }
 
 void Emitter64::MOV64_TO_MEM(REG_64 source, REG_64 indir_dest, uint32_t offset)
 {
     rexw_r_rm(source, indir_dest);
-    cache->write<uint8_t>(0x89);
+    block->write<uint8_t>(0x89);
 
     if ((indir_dest & 7) == 5 || offset)
     {
@@ -1186,1064 +1184,1064 @@ void Emitter64::MOV64_TO_MEM(REG_64 source, REG_64 indir_dest, uint32_t offset)
     else
         modrm(0, source, indir_dest);
     if ((indir_dest & 7) == 4)
-        cache->write<uint8_t>(0x24);
+        block->write<uint8_t>(0x24);
     if ((indir_dest & 7) == 5 || offset)
-        cache->write<uint32_t>(offset);
+        block->write<uint32_t>(offset);
 }
 
 void Emitter64::MOVSX8_TO_64(REG_64 source, REG_64 dest)
 {
     rexw_r_rm(dest, source);
-    cache->write<uint8_t>(0x0F);
-    cache->write<uint8_t>(0xBE);
+    block->write<uint8_t>(0x0F);
+    block->write<uint8_t>(0xBE);
     modrm(0b11, dest, source);
 }
 
 void Emitter64::MOVSX16_TO_32(REG_64 source, REG_64 dest)
 {
     rex_r_rm(dest, source);
-    cache->write<uint8_t>(0x0F);
-    cache->write<uint8_t>(0xBF);
+    block->write<uint8_t>(0x0F);
+    block->write<uint8_t>(0xBF);
     modrm(0b11, dest, source);
 }
 
 void Emitter64::MOVSX16_TO_64(REG_64 source, REG_64 dest)
 {
     rexw_r_rm(dest, source);
-    cache->write<uint8_t>(0x0F);
-    cache->write<uint8_t>(0xBF);
+    block->write<uint8_t>(0x0F);
+    block->write<uint8_t>(0xBF);
     modrm(0b11, dest, source);
 }
 
 void Emitter64::MOVSX32_TO_64(REG_64 source, REG_64 dest)
 {
     rexw_r_rm(dest, source);
-    cache->write<uint8_t>(0x63);
+    block->write<uint8_t>(0x63);
     modrm(0b11, dest, source);
 }
 
 void Emitter64::MOVZX8_TO_32(REG_64 source, REG_64 dest)
 {
     rex_r_rm(dest, source);
-    cache->write<uint8_t>(0x0F);
-    cache->write<uint8_t>(0xB6);
+    block->write<uint8_t>(0x0F);
+    block->write<uint8_t>(0xB6);
     modrm(0b11, dest, source);
 }
 
 void Emitter64::MOVZX8_TO_64(REG_64 source, REG_64 dest)
 {
     rexw_r_rm(dest, source);
-    cache->write<uint8_t>(0x0F);
-    cache->write<uint8_t>(0xB6);
+    block->write<uint8_t>(0x0F);
+    block->write<uint8_t>(0xB6);
     modrm(0b11, dest, source);
 }
 
 void Emitter64::MOVZX16_TO_64(REG_64 source, REG_64 dest)
 {
     rexw_r_rm(dest, source);
-    cache->write<uint8_t>(0x0F);
-    cache->write<uint8_t>(0xB7);
+    block->write<uint8_t>(0x0F);
+    block->write<uint8_t>(0xB7);
     modrm(0b11, dest, source);
 }
 
 void Emitter64::MOVD_FROM_MEM(REG_64 indir_source, REG_64 xmm_dest)
 {
-    cache->write<uint8_t>(0x66);
+    block->write<uint8_t>(0x66);
     rex_r_rm(xmm_dest, indir_source);
-    cache->write<uint8_t>(0x0F);
-    cache->write<uint8_t>(0x6E);
+    block->write<uint8_t>(0x0F);
+    block->write<uint8_t>(0x6E);
     modrm(0, xmm_dest, indir_source);
 }
 
 void Emitter64::MOVD_FROM_XMM(REG_64 xmm_source, REG_64 dest)
 {
-    cache->write<uint8_t>(0x66);
+    block->write<uint8_t>(0x66);
     rex_r_rm(xmm_source, dest);
-    cache->write<uint8_t>(0x0F);
-    cache->write<uint8_t>(0x7E);
+    block->write<uint8_t>(0x0F);
+    block->write<uint8_t>(0x7E);
     modrm(0b11, xmm_source, dest);
 }
 
 void Emitter64::MOVD_TO_MEM(REG_64 xmm_source, REG_64 indir_dest)
 {
-    cache->write<uint8_t>(0x66);
+    block->write<uint8_t>(0x66);
     rex_r_rm(xmm_source, indir_dest);
-    cache->write<uint8_t>(0x0F);
-    cache->write<uint8_t>(0x7E);
+    block->write<uint8_t>(0x0F);
+    block->write<uint8_t>(0x7E);
     modrm(0, xmm_source, indir_dest);
 }
 
 void Emitter64::MOVD_TO_XMM(REG_64 source, REG_64 xmm_dest)
 {
-    cache->write<uint8_t>(0x66);
+    block->write<uint8_t>(0x66);
     rex_r_rm(xmm_dest, source);
-    cache->write<uint8_t>(0x0F);
-    cache->write<uint8_t>(0x6E);
+    block->write<uint8_t>(0x0F);
+    block->write<uint8_t>(0x6E);
     modrm(0b11, xmm_dest, source);
 }
 
 void Emitter64::MOVQ_FROM_XMM(REG_64 xmm_source, REG_64 dest)
 {
-    cache->write<uint8_t>(0x66);
+    block->write<uint8_t>(0x66);
     rexw_r_rm(xmm_source, dest);
-    cache->write<uint8_t>(0x0F);
-    cache->write<uint8_t>(0x7E);
+    block->write<uint8_t>(0x0F);
+    block->write<uint8_t>(0x7E);
     modrm(0b11, xmm_source, dest);
 }
 
 void Emitter64::MOVQ_TO_XMM(REG_64 source, REG_64 xmm_dest)
 {
-    cache->write<uint8_t>(0x66);
+    block->write<uint8_t>(0x66);
     rexw_r_rm(xmm_dest, source);
-    cache->write<uint8_t>(0x0F);
-    cache->write<uint8_t>(0x6E);
+    block->write<uint8_t>(0x0F);
+    block->write<uint8_t>(0x6E);
     modrm(0b11, xmm_dest, source);
 }
 
 void Emitter64::MOVSS_REG(REG_64 xmm_source, REG_64 xmm_dest)
 {
-    cache->write<uint8_t>(0xF3);
+    block->write<uint8_t>(0xF3);
     rex_r_rm(xmm_source, xmm_dest);
-    cache->write<uint8_t>(0x0F);
-    cache->write<uint8_t>(0x11);
+    block->write<uint8_t>(0x0F);
+    block->write<uint8_t>(0x11);
     modrm(0b11, xmm_source, xmm_dest);
 }
 
 void Emitter64::MOVAPS_REG(REG_64 xmm_source, REG_64 xmm_dest)
 {
     rex_r_rm(xmm_source, xmm_dest);
-    cache->write<uint8_t>(0x0F);
-    cache->write<uint8_t>(0x29);
+    block->write<uint8_t>(0x0F);
+    block->write<uint8_t>(0x29);
     modrm(0b11, xmm_source, xmm_dest);
 }
 
 void Emitter64::MOVAPS_FROM_MEM(REG_64 indir_source, REG_64 xmm_dest, uint32_t offset)
 {
     rex_r_rm(xmm_dest, indir_source);
-    cache->write<uint8_t>(0x0F);
-    cache->write<uint8_t>(0x28);
+    block->write<uint8_t>(0x0F);
+    block->write<uint8_t>(0x28);
     if ((indir_source & 7) == 5 || offset)
         modrm(0b10, xmm_dest, indir_source);
     else
         modrm(0b0, xmm_dest, indir_source);
     if ((indir_source & 7) == 4)
-        cache->write<uint8_t>(0x24);
+        block->write<uint8_t>(0x24);
     if ((indir_source & 7) == 5 || offset)
-        cache->write<uint32_t>(offset);
+        block->write<uint32_t>(offset);
 }
 
 void Emitter64::MOVAPS_TO_MEM(REG_64 xmm_source, REG_64 indir_dest, uint32_t offset)
 {
     rex_r_rm(xmm_source, indir_dest);
-    cache->write<uint8_t>(0x0F);
-    cache->write<uint8_t>(0x29);
+    block->write<uint8_t>(0x0F);
+    block->write<uint8_t>(0x29);
     if ((indir_dest & 7) == 5 || offset)
         modrm(0b10, xmm_source, indir_dest);
     else
         modrm(0b0, xmm_source, indir_dest);
     if ((indir_dest & 7) == 4)
-        cache->write<uint8_t>(0x24);
+        block->write<uint8_t>(0x24);
     if ((indir_dest & 7) == 5 || offset)
-        cache->write<uint32_t>(offset);
+        block->write<uint32_t>(offset);
 }
 
 void Emitter64::MOVUPS_FROM_MEM(REG_64 indir_source, REG_64 xmm_dest, uint32_t offset)
 {
     rex_r_rm(xmm_dest, indir_source);
-    cache->write<uint8_t>(0x0F);
-    cache->write<uint8_t>(0x10);
+    block->write<uint8_t>(0x0F);
+    block->write<uint8_t>(0x10);
     if ((indir_source & 7) == 5 || offset)
         modrm(0b10, xmm_dest, indir_source);
     else
         modrm(0b0, xmm_dest, indir_source);
     if ((indir_source & 7) == 4)
-        cache->write<uint8_t>(0x24);
+        block->write<uint8_t>(0x24);
     if ((indir_source & 7) == 5 || offset)
-        cache->write<uint32_t>(offset);
+        block->write<uint32_t>(offset);
 }
 
 void Emitter64::MOVUPS_TO_MEM(REG_64 xmm_source, REG_64 indir_dest, uint32_t offset)
 {
     rex_r_rm(xmm_source, indir_dest);
-    cache->write<uint8_t>(0x0F);
-    cache->write<uint8_t>(0x11);
+    block->write<uint8_t>(0x0F);
+    block->write<uint8_t>(0x11);
     if ((indir_dest & 7) == 5 || offset)
         modrm(0b10, xmm_source, indir_dest);
     else
         modrm(0b0, xmm_source, indir_dest);
     if ((indir_dest & 7) == 4)
-        cache->write<uint8_t>(0x24);
+        block->write<uint8_t>(0x24);
     if ((indir_dest & 7) == 5 || offset)
-        cache->write<uint32_t>(offset);
+        block->write<uint32_t>(offset);
 }
 
 void Emitter64::MOVMSKPS(REG_64 xmm_source, REG_64 dest)
 {
     rex_r_rm(dest, xmm_source);
-    cache->write<uint8_t>(0x0F);
-    cache->write<uint8_t>(0x50);
+    block->write<uint8_t>(0x0F);
+    block->write<uint8_t>(0x50);
     modrm(0b11, dest, xmm_source);
 }
 
 uint8_t* Emitter64::JMP_NEAR_DEFERRED()
 {
-    cache->write<uint8_t>(0xE9);
-    uint8_t* addr = cache->get_current_block_pos();
+    block->write<uint8_t>(0xE9);
+    uint8_t* addr = block->get_code_pos();
 
-    cache->write<uint32_t>(0);
+    block->write<uint32_t>(0);
     return addr;
 }
 
 uint8_t* Emitter64::JCC_NEAR_DEFERRED(ConditionCode cc)
 {
-    cache->write<uint8_t>(0x0F);
-    cache->write<uint8_t>((int)cc | 0x80);
-    uint8_t* addr = cache->get_current_block_pos();
+    block->write<uint8_t>(0x0F);
+    block->write<uint8_t>((int)cc | 0x80);
+    uint8_t* addr = block->get_code_pos();
 
-    cache->write<uint32_t>(0);
+    block->write<uint32_t>(0);
     return addr;
 }
 
 void Emitter64::set_jump_dest(uint8_t *jump)
 {
-    uint8_t* jump_dest_addr = cache->get_current_block_pos();
+    uint8_t* jump_dest_addr = block->get_code_pos();
 
-    cache->set_current_block_pos(jump);
+    block->set_code_pos(jump);
     int jump_offset = jump_dest_addr - jump - 4;
-    cache->write<uint32_t>(jump_offset);
+    block->write<uint32_t>(jump_offset);
 
-    cache->set_current_block_pos(jump_dest_addr);
+    block->set_code_pos(jump_dest_addr);
 }
 
 void Emitter64::PUSH(REG_64 reg)
 {
     rex_rm(reg);
-    cache->write<uint8_t>(0x50 + (reg & 0x7));
+    block->write<uint8_t>(0x50 + (reg & 0x7));
 }
 
 void Emitter64::POP(REG_64 reg)
 {
     rex_rm(reg);
-    cache->write<uint8_t>(0x58 + (reg & 0x7));
+    block->write<uint8_t>(0x58 + (reg & 0x7));
 }
 
 void Emitter64::CALL(uint64_t func)
 {
     int offset = func;
-    offset -= (uint64_t)cache->get_current_block_pos();
-    cache->write<uint8_t>(0xE8);
-    cache->write<uint32_t>(offset - 5);
+    offset -= (uint64_t) block->get_code_pos();
+    block->write<uint8_t>(0xE8);
+    block->write<uint32_t>(offset - 5);
 }
 
 void Emitter64::CALL_INDIR(REG_64 source)
 {
     rex_rm(source);
-    cache->write<uint8_t>(0xFF);
+    block->write<uint8_t>(0xFF);
     modrm(0b11, 2, source);
 }
 
 void Emitter64::RET()
 {
-    cache->write<uint8_t>(0xC3);
+    block->write<uint8_t>(0xC3);
 }
 
 void Emitter64::PACKUSDW(REG_64 xmm_source, REG_64 xmm_dest)
 {
-    cache->write<uint8_t>(0x66);
+    block->write<uint8_t>(0x66);
     rex_r_rm(xmm_dest, xmm_source);
-    cache->write<uint8_t>(0x0F);
-    cache->write<uint8_t>(0x38);
-    cache->write<uint8_t>(0x2B);
+    block->write<uint8_t>(0x0F);
+    block->write<uint8_t>(0x38);
+    block->write<uint8_t>(0x2B);
     modrm(0b11, xmm_dest, xmm_source);
 }
 
 void Emitter64::PACKUSWB(REG_64 xmm_source, REG_64 xmm_dest)
 {
-    cache->write<uint8_t>(0x66);
+    block->write<uint8_t>(0x66);
     rex_r_rm(xmm_dest, xmm_source);
-    cache->write<uint8_t>(0x0F);
-    cache->write<uint8_t>(0x67);
+    block->write<uint8_t>(0x0F);
+    block->write<uint8_t>(0x67);
     modrm(0b11, xmm_dest, xmm_source);
 }
 
 void Emitter64::PABSB(REG_64 xmm_source, REG_64 xmm_dest)
 {
-    cache->write<uint8_t>(0x66);
+    block->write<uint8_t>(0x66);
     rex_r_rm(xmm_dest, xmm_source);
-    cache->write<uint8_t>(0x0F);
-    cache->write<uint8_t>(0x38);
-    cache->write<uint8_t>(0x1C);
+    block->write<uint8_t>(0x0F);
+    block->write<uint8_t>(0x38);
+    block->write<uint8_t>(0x1C);
     modrm(0b11, xmm_dest, xmm_source);
 }
 
 void Emitter64::PABSD(REG_64 xmm_source, REG_64 xmm_dest)
 {
-    cache->write<uint8_t>(0x66);
+    block->write<uint8_t>(0x66);
     rex_r_rm(xmm_dest, xmm_source);
-    cache->write<uint8_t>(0x0F);
-    cache->write<uint8_t>(0x38);
-    cache->write<uint8_t>(0x1E);
+    block->write<uint8_t>(0x0F);
+    block->write<uint8_t>(0x38);
+    block->write<uint8_t>(0x1E);
     modrm(0b11, xmm_dest, xmm_source);
 }
 
 void Emitter64::PABSW(REG_64 xmm_source, REG_64 xmm_dest)
 {
-    cache->write<uint8_t>(0x66);
+    block->write<uint8_t>(0x66);
     rex_r_rm(xmm_dest, xmm_source);
-    cache->write<uint8_t>(0x0F);
-    cache->write<uint8_t>(0x38);
-    cache->write<uint8_t>(0x1D);
+    block->write<uint8_t>(0x0F);
+    block->write<uint8_t>(0x38);
+    block->write<uint8_t>(0x1D);
     modrm(0b11, xmm_dest, xmm_source);
 }
 
 void Emitter64::PADDB(REG_64 xmm_source, REG_64 xmm_dest)
 {
-    cache->write<uint8_t>(0x66);
+    block->write<uint8_t>(0x66);
     rex_r_rm(xmm_dest, xmm_source);
-    cache->write<uint8_t>(0x0F);
-    cache->write<uint8_t>(0xFC);
+    block->write<uint8_t>(0x0F);
+    block->write<uint8_t>(0xFC);
     modrm(0b11, xmm_dest, xmm_source);
 }
 
 void Emitter64::PADDD(REG_64 xmm_source, REG_64 xmm_dest)
 {
-    cache->write<uint8_t>(0x66);
+    block->write<uint8_t>(0x66);
     rex_r_rm(xmm_dest, xmm_source);
-    cache->write<uint8_t>(0x0F);
-    cache->write<uint8_t>(0xFE);
+    block->write<uint8_t>(0x0F);
+    block->write<uint8_t>(0xFE);
     modrm(0b11, xmm_dest, xmm_source);
 }
 
 void Emitter64::PADDW(REG_64 xmm_source, REG_64 xmm_dest)
 {
-    cache->write<uint8_t>(0x66);
+    block->write<uint8_t>(0x66);
     rex_r_rm(xmm_dest, xmm_source);
-    cache->write<uint8_t>(0x0F);
-    cache->write<uint8_t>(0xFD);
+    block->write<uint8_t>(0x0F);
+    block->write<uint8_t>(0xFD);
     modrm(0b11, xmm_dest, xmm_source);
 }
 
 void Emitter64::PADDSB(REG_64 xmm_source, REG_64 xmm_dest)
 {
-    cache->write<uint8_t>(0x66);
+    block->write<uint8_t>(0x66);
     rex_r_rm(xmm_dest, xmm_source);
-    cache->write<uint8_t>(0x0F);
-    cache->write<uint8_t>(0xEC);
+    block->write<uint8_t>(0x0F);
+    block->write<uint8_t>(0xEC);
     modrm(0b11, xmm_dest, xmm_source);
 }
 
 void Emitter64::PADDSW(REG_64 xmm_source, REG_64 xmm_dest)
 {
-    cache->write<uint8_t>(0x66);
+    block->write<uint8_t>(0x66);
     rex_r_rm(xmm_dest, xmm_source);
-    cache->write<uint8_t>(0x0F);
-    cache->write<uint8_t>(0xED);
+    block->write<uint8_t>(0x0F);
+    block->write<uint8_t>(0xED);
     modrm(0b11, xmm_dest, xmm_source);
 }
 
 void Emitter64::PADDUSB(REG_64 xmm_source, REG_64 xmm_dest)
 {
-    cache->write<uint8_t>(0x66);
+    block->write<uint8_t>(0x66);
     rex_r_rm(xmm_dest, xmm_source);
-    cache->write<uint8_t>(0x0F);
-    cache->write<uint8_t>(0xDC);
+    block->write<uint8_t>(0x0F);
+    block->write<uint8_t>(0xDC);
     modrm(0b11, xmm_dest, xmm_source);
 }
 
 void Emitter64::PADDUSW(REG_64 xmm_source, REG_64 xmm_dest)
 {
-    cache->write<uint8_t>(0x66);
+    block->write<uint8_t>(0x66);
     rex_r_rm(xmm_dest, xmm_source);
-    cache->write<uint8_t>(0x0F);
-    cache->write<uint8_t>(0xDD);
+    block->write<uint8_t>(0x0F);
+    block->write<uint8_t>(0xDD);
     modrm(0b11, xmm_dest, xmm_source);
 }
 
 void Emitter64::PAND_XMM(REG_64 xmm_source, REG_64 xmm_dest)
 {
-    cache->write<uint8_t>(0x66);
+    block->write<uint8_t>(0x66);
     rex_r_rm(xmm_dest, xmm_source);
-    cache->write<uint8_t>(0x0F);
-    cache->write<uint8_t>(0xDB);
+    block->write<uint8_t>(0x0F);
+    block->write<uint8_t>(0xDB);
     modrm(0b11, xmm_dest, xmm_source);
 }
 
 void Emitter64::PAND_XMM_FROM_MEM(REG_64 indir_source, REG_64 xmm_dest, uint32_t offset)
 {
-    cache->write<uint8_t>(0x66);
+    block->write<uint8_t>(0x66);
     rex_r_rm(xmm_dest, indir_source);
-    cache->write<uint8_t>(0x0F);
-    cache->write<uint8_t>(0xDB);
+    block->write<uint8_t>(0x0F);
+    block->write<uint8_t>(0xDB);
     modrm(0, xmm_dest, indir_source);
     if ((indir_source & 7) == 4)
-        cache->write<uint8_t>(0x24);
+        block->write<uint8_t>(0x24);
     if ((indir_source & 7) == 5 || offset)
-        cache->write<uint32_t>(offset);
+        block->write<uint32_t>(offset);
 }
 
 void Emitter64::PANDN_XMM(REG_64 xmm_source, REG_64 xmm_dest)
 {
-    cache->write<uint8_t>(0x66);
+    block->write<uint8_t>(0x66);
     rex_r_rm(xmm_dest, xmm_source);
-    cache->write<uint8_t>(0x0F);
-    cache->write<uint8_t>(0xDF);
+    block->write<uint8_t>(0x0F);
+    block->write<uint8_t>(0xDF);
     modrm(0b11, xmm_dest, xmm_source);
 }
 
 void Emitter64::PANDN_XMM_FROM_MEM(REG_64 indir_source, REG_64 xmm_dest, uint32_t offset)
 {
-    cache->write<uint8_t>(0x66);
+    block->write<uint8_t>(0x66);
     rex_r_rm(xmm_dest, indir_source);
-    cache->write<uint8_t>(0x0F);
-    cache->write<uint8_t>(0xDF);
+    block->write<uint8_t>(0x0F);
+    block->write<uint8_t>(0xDF);
     modrm(0, xmm_dest, indir_source);
     if ((indir_source & 7) == 4)
-        cache->write<uint8_t>(0x24);
+        block->write<uint8_t>(0x24);
     if ((indir_source & 7) == 5 || offset)
-        cache->write<uint32_t>(offset);
+        block->write<uint32_t>(offset);
 }
 
 void Emitter64::PCMPEQB_XMM(REG_64 xmm_source, REG_64 xmm_dest)
 {
-    cache->write<uint8_t>(0x66);
+    block->write<uint8_t>(0x66);
     rex_r_rm(xmm_dest, xmm_source);
-    cache->write<uint8_t>(0x0F);
-    cache->write<uint8_t>(0x74);
+    block->write<uint8_t>(0x0F);
+    block->write<uint8_t>(0x74);
     modrm(0b11, xmm_dest, xmm_source);
 }
 
 void Emitter64::PCMPEQD_XMM(REG_64 xmm_source, REG_64 xmm_dest)
 {
-    cache->write<uint8_t>(0x66);
+    block->write<uint8_t>(0x66);
     rex_r_rm(xmm_dest, xmm_source);
-    cache->write<uint8_t>(0x0F);
-    cache->write<uint8_t>(0x76);
+    block->write<uint8_t>(0x0F);
+    block->write<uint8_t>(0x76);
     modrm(0b11, xmm_dest, xmm_source);
 }
 
 void Emitter64::PCMPEQW_XMM(REG_64 xmm_source, REG_64 xmm_dest)
 {
-    cache->write<uint8_t>(0x66);
+    block->write<uint8_t>(0x66);
     rex_r_rm(xmm_dest, xmm_source);
-    cache->write<uint8_t>(0x0F);
-    cache->write<uint8_t>(0x75);
+    block->write<uint8_t>(0x0F);
+    block->write<uint8_t>(0x75);
     modrm(0b11, xmm_dest, xmm_source);
 }
 
 void Emitter64::PCMPGTB_XMM(REG_64 xmm_source, REG_64 xmm_dest)
 {
-    cache->write<uint8_t>(0x66);
+    block->write<uint8_t>(0x66);
     rex_r_rm(xmm_dest, xmm_source);
-    cache->write<uint8_t>(0x0F);
-    cache->write<uint8_t>(0x64);
+    block->write<uint8_t>(0x0F);
+    block->write<uint8_t>(0x64);
     modrm(0b11, xmm_dest, xmm_source);
 }
 
 void Emitter64::PCMPGTW_XMM(REG_64 xmm_source, REG_64 xmm_dest)
 {
-    cache->write<uint8_t>(0x66);
+    block->write<uint8_t>(0x66);
     rex_r_rm(xmm_dest, xmm_source);
-    cache->write<uint8_t>(0x0F);
-    cache->write<uint8_t>(0x65);
+    block->write<uint8_t>(0x0F);
+    block->write<uint8_t>(0x65);
     modrm(0b11, xmm_dest, xmm_source);
 }
 
 void Emitter64::PCMPGTD_XMM(REG_64 xmm_source, REG_64 xmm_dest)
 {
-    cache->write<uint8_t>(0x66);
+    block->write<uint8_t>(0x66);
     rex_r_rm(xmm_dest, xmm_source);
-    cache->write<uint8_t>(0x0F);
-    cache->write<uint8_t>(0x66);
+    block->write<uint8_t>(0x0F);
+    block->write<uint8_t>(0x66);
     modrm(0b11, xmm_dest, xmm_source);
 }
 
 
 void Emitter64::PEXTRB_XMM(uint8_t imm, REG_64 xmm_source, REG_64 dest)
 {
-    cache->write<uint8_t>(0x66);
+    block->write<uint8_t>(0x66);
     rex_r_rm(xmm_source, dest);
-    cache->write<uint8_t>(0x0F);
-    cache->write<uint8_t>(0x3A);
-    cache->write<uint8_t>(0x14);
+    block->write<uint8_t>(0x0F);
+    block->write<uint8_t>(0x3A);
+    block->write<uint8_t>(0x14);
     modrm(0b11, xmm_source, dest);
-    cache->write<uint8_t>(imm);
+    block->write<uint8_t>(imm);
 }
 
 void Emitter64::PEXTRW_XMM(uint8_t imm, REG_64 xmm_source, REG_64 dest)
 {
-    cache->write<uint8_t>(0x66);
+    block->write<uint8_t>(0x66);
     rex_r_rm(dest, xmm_source);
-    cache->write<uint8_t>(0x0F);
-    cache->write<uint8_t>(0xC5);
+    block->write<uint8_t>(0x0F);
+    block->write<uint8_t>(0xC5);
     modrm(0b11, dest, xmm_source);
-    cache->write<uint8_t>(imm);
+    block->write<uint8_t>(imm);
 }
 
 void Emitter64::PEXTRD_XMM(uint8_t imm, REG_64 xmm_source, REG_64 dest)
 {
-    cache->write<uint8_t>(0x66);
+    block->write<uint8_t>(0x66);
     rex_r_rm(xmm_source, dest);
-    cache->write<uint8_t>(0x0F);
-    cache->write<uint8_t>(0x3A);
-    cache->write<uint8_t>(0x16);
+    block->write<uint8_t>(0x0F);
+    block->write<uint8_t>(0x3A);
+    block->write<uint8_t>(0x16);
     modrm(0b11, xmm_source, dest);
-    cache->write<uint8_t>(imm);
+    block->write<uint8_t>(imm);
 }
 
 void Emitter64::PEXTRQ_XMM(uint8_t imm, REG_64 xmm_source, REG_64 dest)
 {
-    cache->write<uint8_t>(0x66);
+    block->write<uint8_t>(0x66);
     rexw_r_rm(xmm_source, dest);
-    cache->write<uint8_t>(0x0F);
-    cache->write<uint8_t>(0x3A);
-    cache->write<uint8_t>(0x16);
+    block->write<uint8_t>(0x0F);
+    block->write<uint8_t>(0x3A);
+    block->write<uint8_t>(0x16);
     modrm(0b11, xmm_source, dest);
-    cache->write<uint8_t>(imm);
+    block->write<uint8_t>(imm);
 }
 
 void Emitter64::PINSRB_XMM(uint8_t imm, REG_64 source, REG_64 xmm_dest)
 {
-    cache->write<uint8_t>(0x66);
+    block->write<uint8_t>(0x66);
     rex_r_rm(xmm_dest, source);
-    cache->write<uint8_t>(0x0F);
-    cache->write<uint8_t>(0x3A);
-    cache->write<uint8_t>(0x20);
+    block->write<uint8_t>(0x0F);
+    block->write<uint8_t>(0x3A);
+    block->write<uint8_t>(0x20);
     modrm(0b11, xmm_dest, source);
-    cache->write<uint8_t>(imm);
+    block->write<uint8_t>(imm);
 }
 
 void Emitter64::PINSRW_XMM(uint8_t imm, REG_64 source, REG_64 xmm_dest)
 {
-    cache->write<uint8_t>(0x66);
+    block->write<uint8_t>(0x66);
     rex_r_rm(xmm_dest, source);
-    cache->write<uint8_t>(0x0F);
-    cache->write<uint8_t>(0xC4);
+    block->write<uint8_t>(0x0F);
+    block->write<uint8_t>(0xC4);
     modrm(0b11, xmm_dest, source);
-    cache->write<uint8_t>(imm);
+    block->write<uint8_t>(imm);
 }
 
 void Emitter64::PINSRD_XMM(uint8_t imm, REG_64 source, REG_64 xmm_dest)
 {
-    cache->write<uint8_t>(0x66);
+    block->write<uint8_t>(0x66);
     rex_r_rm(xmm_dest, source);
-    cache->write<uint8_t>(0x0F);
-    cache->write<uint8_t>(0x3A);
-    cache->write<uint8_t>(0x22);
+    block->write<uint8_t>(0x0F);
+    block->write<uint8_t>(0x3A);
+    block->write<uint8_t>(0x22);
     modrm(0b11, xmm_dest, source);
-    cache->write<uint8_t>(imm);
+    block->write<uint8_t>(imm);
 }
 
 void Emitter64::PINSRQ_XMM(uint8_t imm, REG_64 source, REG_64 xmm_dest)
 {
-    cache->write<uint8_t>(0x66);
+    block->write<uint8_t>(0x66);
     rexw_r_rm(xmm_dest, source);
-    cache->write<uint8_t>(0x0F);
-    cache->write<uint8_t>(0x3A);
-    cache->write<uint8_t>(0x22);
+    block->write<uint8_t>(0x0F);
+    block->write<uint8_t>(0x3A);
+    block->write<uint8_t>(0x22);
     modrm(0b11, xmm_dest, source);
-    cache->write<uint8_t>(imm);
+    block->write<uint8_t>(imm);
 }
 
 void Emitter64::PMAXSB_XMM(REG_64 xmm_source, REG_64 xmm_dest)
 {
-    cache->write<uint8_t>(0x66);
+    block->write<uint8_t>(0x66);
     rex_r_rm(xmm_dest, xmm_source);
-    cache->write<uint8_t>(0x0F);
-    cache->write<uint8_t>(0x38);
-    cache->write<uint8_t>(0x3C);
+    block->write<uint8_t>(0x0F);
+    block->write<uint8_t>(0x38);
+    block->write<uint8_t>(0x3C);
     modrm(0b11, xmm_dest, xmm_source);
 }
 
 void Emitter64::PMAXSD_XMM(REG_64 xmm_source, REG_64 xmm_dest)
 {
-    cache->write<uint8_t>(0x66);
+    block->write<uint8_t>(0x66);
     rex_r_rm(xmm_dest, xmm_source);
-    cache->write<uint8_t>(0x0F);
-    cache->write<uint8_t>(0x38);
-    cache->write<uint8_t>(0x3D);
+    block->write<uint8_t>(0x0F);
+    block->write<uint8_t>(0x38);
+    block->write<uint8_t>(0x3D);
     modrm(0b11, xmm_dest, xmm_source);
 }
 
 void Emitter64::PMAXSW_XMM(REG_64 xmm_source, REG_64 xmm_dest)
 {
-    cache->write<uint8_t>(0x66);
+    block->write<uint8_t>(0x66);
     rex_r_rm(xmm_dest, xmm_source);
-    cache->write<uint8_t>(0x0F);
-    cache->write<uint8_t>(0xEE);
+    block->write<uint8_t>(0x0F);
+    block->write<uint8_t>(0xEE);
     modrm(0b11, xmm_dest, xmm_source);
 }
 
 void Emitter64::PMAXUB_XMM(REG_64 xmm_source, REG_64 xmm_dest)
 {
-    cache->write<uint8_t>(0x66);
+    block->write<uint8_t>(0x66);
     rex_r_rm(xmm_dest, xmm_source);
-    cache->write<uint8_t>(0x0F);
-    cache->write<uint8_t>(0xDE);
+    block->write<uint8_t>(0x0F);
+    block->write<uint8_t>(0xDE);
     modrm(0b11, xmm_dest, xmm_source);
 }
 
 void Emitter64::PMAXUD_XMM(REG_64 xmm_source, REG_64 xmm_dest)
 {
-    cache->write<uint8_t>(0x66);
+    block->write<uint8_t>(0x66);
     rex_r_rm(xmm_dest, xmm_source);
-    cache->write<uint8_t>(0x0F);
-    cache->write<uint8_t>(0x38);
-    cache->write<uint8_t>(0x3F);
+    block->write<uint8_t>(0x0F);
+    block->write<uint8_t>(0x38);
+    block->write<uint8_t>(0x3F);
     modrm(0b11, xmm_dest, xmm_source);
 }
 
 void Emitter64::PMAXUW_XMM(REG_64 xmm_source, REG_64 xmm_dest)
 {
-    cache->write<uint8_t>(0x66);
+    block->write<uint8_t>(0x66);
     rex_r_rm(xmm_dest, xmm_source);
-    cache->write<uint8_t>(0x0F);
-    cache->write<uint8_t>(0x38);
-    cache->write<uint8_t>(0x3E);
+    block->write<uint8_t>(0x0F);
+    block->write<uint8_t>(0x38);
+    block->write<uint8_t>(0x3E);
     modrm(0b11, xmm_dest, xmm_source);
 }
 
 void Emitter64::PMINSB_XMM(REG_64 xmm_source, REG_64 xmm_dest)
 {
-    cache->write<uint8_t>(0x66);
+    block->write<uint8_t>(0x66);
     rex_r_rm(xmm_dest, xmm_source);
-    cache->write<uint8_t>(0x0F);
-    cache->write<uint8_t>(0x38);
-    cache->write<uint8_t>(0x38);
+    block->write<uint8_t>(0x0F);
+    block->write<uint8_t>(0x38);
+    block->write<uint8_t>(0x38);
     modrm(0b11, xmm_dest, xmm_source);
 }
 
 void Emitter64::PMINSD_XMM(REG_64 xmm_source, REG_64 xmm_dest)
 {
-    cache->write<uint8_t>(0x66);
+    block->write<uint8_t>(0x66);
     rex_r_rm(xmm_dest, xmm_source);
-    cache->write<uint8_t>(0x0F);
-    cache->write<uint8_t>(0x38);
-    cache->write<uint8_t>(0x39);
+    block->write<uint8_t>(0x0F);
+    block->write<uint8_t>(0x38);
+    block->write<uint8_t>(0x39);
     modrm(0b11, xmm_dest, xmm_source);
 }
 
 void Emitter64::PMINSW_XMM(REG_64 xmm_source, REG_64 xmm_dest)
 {
-    cache->write<uint8_t>(0x66);
+    block->write<uint8_t>(0x66);
     rex_r_rm(xmm_dest, xmm_source);
-    cache->write<uint8_t>(0x0F);
-    cache->write<uint8_t>(0xEA);
+    block->write<uint8_t>(0x0F);
+    block->write<uint8_t>(0xEA);
     modrm(0b11, xmm_dest, xmm_source);
 }
 
 void Emitter64::PMINSD_XMM_FROM_MEM(REG_64 indir_source, REG_64 xmm_dest, uint32_t offset)
 {
-    cache->write<uint8_t>(0x66);
+    block->write<uint8_t>(0x66);
     rex_r_rm(xmm_dest, indir_source);
-    cache->write<uint8_t>(0x0F);
-    cache->write<uint8_t>(0x38);
-    cache->write<uint8_t>(0x39);
+    block->write<uint8_t>(0x0F);
+    block->write<uint8_t>(0x38);
+    block->write<uint8_t>(0x39);
     modrm(0, xmm_dest, indir_source);
     if ((indir_source & 7) == 4)
-        cache->write<uint8_t>(0x24);
+        block->write<uint8_t>(0x24);
     if ((indir_source & 7) == 5 || offset)
-        cache->write<uint32_t>(offset);
+        block->write<uint32_t>(offset);
 }
 
 void Emitter64::PMINUB_XMM(REG_64 xmm_source, REG_64 xmm_dest)
 {
-    cache->write<uint8_t>(0x66);
+    block->write<uint8_t>(0x66);
     rex_r_rm(xmm_dest, xmm_source);
-    cache->write<uint8_t>(0x0F);
-    cache->write<uint8_t>(0xDA);
+    block->write<uint8_t>(0x0F);
+    block->write<uint8_t>(0xDA);
     modrm(0b11, xmm_dest, xmm_source);
 }
 
 void Emitter64::PMINUD_XMM(REG_64 xmm_source, REG_64 xmm_dest)
 {
-    cache->write<uint8_t>(0x66);
+    block->write<uint8_t>(0x66);
     rex_r_rm(xmm_dest, xmm_source);
-    cache->write<uint8_t>(0x0F);
-    cache->write<uint8_t>(0x38);
-    cache->write<uint8_t>(0x3B);
+    block->write<uint8_t>(0x0F);
+    block->write<uint8_t>(0x38);
+    block->write<uint8_t>(0x3B);
     modrm(0b11, xmm_dest, xmm_source);
 }
 
 void Emitter64::PMINUW_XMM(REG_64 xmm_source, REG_64 xmm_dest)
 {
-    cache->write<uint8_t>(0x66);
+    block->write<uint8_t>(0x66);
     rex_r_rm(xmm_dest, xmm_source);
-    cache->write<uint8_t>(0x0F);
-    cache->write<uint8_t>(0x38);
-    cache->write<uint8_t>(0x3A);
+    block->write<uint8_t>(0x0F);
+    block->write<uint8_t>(0x38);
+    block->write<uint8_t>(0x3A);
     modrm(0b11, xmm_dest, xmm_source);
 }
 
 void Emitter64::PMINUD_XMM_FROM_MEM(REG_64 indir_source, REG_64 xmm_dest, uint32_t offset)
 {
-    cache->write<uint8_t>(0x66);
+    block->write<uint8_t>(0x66);
     rex_r_rm(xmm_dest, indir_source);
-    cache->write<uint8_t>(0x0F);
-    cache->write<uint8_t>(0x38);
-    cache->write<uint8_t>(0x3B);
+    block->write<uint8_t>(0x0F);
+    block->write<uint8_t>(0x38);
+    block->write<uint8_t>(0x3B);
     modrm(0, xmm_dest, indir_source);
     if ((indir_source & 7) == 4)
-        cache->write<uint8_t>(0x24);
+        block->write<uint8_t>(0x24);
     if ((indir_source & 7) == 5 || offset)
-        cache->write<uint32_t>(offset);
+        block->write<uint32_t>(offset);
 }
 
 void Emitter64::PMOVZX8_TO_16(REG_64 xmm_source, REG_64 xmm_dest)
 {
-    cache->write<uint8_t>(0x66);
+    block->write<uint8_t>(0x66);
     rex_r_rm(xmm_dest, xmm_source);
-    cache->write<uint8_t>(0x0F);
-    cache->write<uint8_t>(0x38);
-    cache->write<uint8_t>(0x30);
+    block->write<uint8_t>(0x0F);
+    block->write<uint8_t>(0x38);
+    block->write<uint8_t>(0x30);
     modrm(0b11, xmm_dest, xmm_source);
 }
 
 void Emitter64::PMULLW(REG_64 xmm_source, REG_64 xmm_dest)
 {
-    cache->write<uint8_t>(0x66);
+    block->write<uint8_t>(0x66);
     rex_r_rm(xmm_dest, xmm_source);
-    cache->write<uint8_t>(0x0F);
-    cache->write<uint8_t>(0xD5);
+    block->write<uint8_t>(0x0F);
+    block->write<uint8_t>(0xD5);
     modrm(0b11, xmm_dest, xmm_source);
 }
 
 void Emitter64::POR_XMM(REG_64 xmm_source, REG_64 xmm_dest)
 {
-    cache->write<uint8_t>(0x66);
+    block->write<uint8_t>(0x66);
     rex_r_rm(xmm_dest, xmm_source);
-    cache->write<uint8_t>(0x0F);
-    cache->write<uint8_t>(0xEB);
+    block->write<uint8_t>(0x0F);
+    block->write<uint8_t>(0xEB);
     modrm(0b11, xmm_dest, xmm_source);
 }
 
 void Emitter64::POR_XMM_FROM_MEM(REG_64 indir_source, REG_64 xmm_dest, uint32_t offset)
 {
-    cache->write<uint8_t>(0x66);
+    block->write<uint8_t>(0x66);
     rex_r_rm(xmm_dest, indir_source);
-    cache->write<uint8_t>(0x0F);
-    cache->write<uint8_t>(0xEB);
+    block->write<uint8_t>(0x0F);
+    block->write<uint8_t>(0xEB);
     modrm(0, xmm_dest, indir_source);
     if ((indir_source & 7) == 4)
-        cache->write<uint8_t>(0x24);
+        block->write<uint8_t>(0x24);
     if ((indir_source & 7) == 5 || offset)
-        cache->write<uint32_t>(offset);
+        block->write<uint32_t>(offset);
 }
 
 void Emitter64::PSHUFD(uint8_t imm, REG_64 xmm_source, REG_64 xmm_dest)
 {
-    cache->write<uint8_t>(0x66);
+    block->write<uint8_t>(0x66);
     rex_r_rm(xmm_dest, xmm_source);
-    cache->write<uint8_t>(0x0F);
-    cache->write<uint8_t>(0x70);
+    block->write<uint8_t>(0x0F);
+    block->write<uint8_t>(0x70);
     modrm(0b11, xmm_dest, xmm_source);
-    cache->write<uint8_t>(imm);
+    block->write<uint8_t>(imm);
 }
 
 void Emitter64::PSHUFHW(uint8_t imm, REG_64 xmm_source, REG_64 xmm_dest)
 {
-    cache->write<uint8_t>(0xF3);
+    block->write<uint8_t>(0xF3);
     rex_r_rm(xmm_dest, xmm_source);
-    cache->write<uint8_t>(0x0F);
-    cache->write<uint8_t>(0x70);
+    block->write<uint8_t>(0x0F);
+    block->write<uint8_t>(0x70);
     modrm(0b11, xmm_dest, xmm_source);
-    cache->write<uint8_t>(imm);
+    block->write<uint8_t>(imm);
 }
 
 void Emitter64::PSHUFLW(uint8_t imm, REG_64 xmm_source, REG_64 xmm_dest)
 {
-    cache->write<uint8_t>(0xF2);
+    block->write<uint8_t>(0xF2);
     rex_r_rm(xmm_dest, xmm_source);
-    cache->write<uint8_t>(0x0F);
-    cache->write<uint8_t>(0x70);
+    block->write<uint8_t>(0x0F);
+    block->write<uint8_t>(0x70);
     modrm(0b11, xmm_dest, xmm_source);
-    cache->write<uint8_t>(imm);
+    block->write<uint8_t>(imm);
 }
 
 void Emitter64::PSLLW(int shift, REG_64 xmm_dest)
 {
-    cache->write<uint8_t>(0x66);
+    block->write<uint8_t>(0x66);
     rex_rm(xmm_dest);
-    cache->write<uint8_t>(0x0F);
-    cache->write<uint8_t>(0x71);
+    block->write<uint8_t>(0x0F);
+    block->write<uint8_t>(0x71);
     modrm(0b11, 6, xmm_dest);
-    cache->write<uint8_t>(shift);
+    block->write<uint8_t>(shift);
 }
 
 void Emitter64::PSLLD(int shift, REG_64 xmm_dest)
 {
-    cache->write<uint8_t>(0x66);
+    block->write<uint8_t>(0x66);
     rex_rm(xmm_dest);
-    cache->write<uint8_t>(0x0F);
-    cache->write<uint8_t>(0x72);
+    block->write<uint8_t>(0x0F);
+    block->write<uint8_t>(0x72);
     modrm(0b11, 6, xmm_dest);
-    cache->write<uint8_t>(shift);
+    block->write<uint8_t>(shift);
 }
 
 void Emitter64::PSLLQ(int shift, REG_64 xmm_dest)
 {
-    cache->write<uint8_t>(0x66);
+    block->write<uint8_t>(0x66);
     rex_rm(xmm_dest);
-    cache->write<uint8_t>(0x0F);
-    cache->write<uint8_t>(0x73);
+    block->write<uint8_t>(0x0F);
+    block->write<uint8_t>(0x73);
     modrm(0b11, 6, xmm_dest);
-    cache->write<uint8_t>(shift);
+    block->write<uint8_t>(shift);
 }
 
 void Emitter64::PSRAW(int shift, REG_64 xmm_dest)
 {
-    cache->write<uint8_t>(0x66);
+    block->write<uint8_t>(0x66);
     rex_rm(xmm_dest);
-    cache->write<uint8_t>(0x0F);
-    cache->write<uint8_t>(0x71);
+    block->write<uint8_t>(0x0F);
+    block->write<uint8_t>(0x71);
     modrm(0b11, 4, xmm_dest);
-    cache->write<uint8_t>(shift);
+    block->write<uint8_t>(shift);
 }
 
 void Emitter64::PSRAD(int shift, REG_64 xmm_dest)
 {
-    cache->write<uint8_t>(0x66);
+    block->write<uint8_t>(0x66);
     rex_rm(xmm_dest);
-    cache->write<uint8_t>(0x0F);
-    cache->write<uint8_t>(0x72);
+    block->write<uint8_t>(0x0F);
+    block->write<uint8_t>(0x72);
     modrm(0b11, 4, xmm_dest);
-    cache->write<uint8_t>(shift);
+    block->write<uint8_t>(shift);
 }
 
 void Emitter64::PSRLW(int shift, REG_64 xmm_dest)
 {
-    cache->write<uint8_t>(0x66);
+    block->write<uint8_t>(0x66);
     rex_rm(xmm_dest);
-    cache->write<uint8_t>(0x0F);
-    cache->write<uint8_t>(0x71);
+    block->write<uint8_t>(0x0F);
+    block->write<uint8_t>(0x71);
     modrm(0b11, 2, xmm_dest);
-    cache->write<uint8_t>(shift);
+    block->write<uint8_t>(shift);
 }
 
 void Emitter64::PSRLD(int shift, REG_64 xmm_dest)
 {
-    cache->write<uint8_t>(0x66);
+    block->write<uint8_t>(0x66);
     rex_rm(xmm_dest);
-    cache->write<uint8_t>(0x0F);
-    cache->write<uint8_t>(0x72);
+    block->write<uint8_t>(0x0F);
+    block->write<uint8_t>(0x72);
     modrm(0b11, 2, xmm_dest);
-    cache->write<uint8_t>(shift);
+    block->write<uint8_t>(shift);
 }
 
 void Emitter64::PSRLQ(int shift, REG_64 xmm_dest)
 {
-    cache->write<uint8_t>(0x66);
+    block->write<uint8_t>(0x66);
     rex_rm(xmm_dest);
-    cache->write<uint8_t>(0x0F);
-    cache->write<uint8_t>(0x73);
+    block->write<uint8_t>(0x0F);
+    block->write<uint8_t>(0x73);
     modrm(0b11, 2, xmm_dest);
-    cache->write<uint8_t>(shift);
+    block->write<uint8_t>(shift);
 }
 
 void Emitter64::PSUBB(REG_64 xmm_source, REG_64 xmm_dest)
 {
-    cache->write<uint8_t>(0x66);
+    block->write<uint8_t>(0x66);
     rex_r_rm(xmm_dest, xmm_source);
-    cache->write<uint8_t>(0x0F);
-    cache->write<uint8_t>(0xF8);
+    block->write<uint8_t>(0x0F);
+    block->write<uint8_t>(0xF8);
     modrm(0b11, xmm_dest, xmm_source);
 }
 
 void Emitter64::PSUBD(REG_64 xmm_source, REG_64 xmm_dest)
 {
-    cache->write<uint8_t>(0x66);
+    block->write<uint8_t>(0x66);
     rex_r_rm(xmm_dest, xmm_source);
-    cache->write<uint8_t>(0x0F);
-    cache->write<uint8_t>(0xFA);
+    block->write<uint8_t>(0x0F);
+    block->write<uint8_t>(0xFA);
     modrm(0b11, xmm_dest, xmm_source);
 }
 
 void Emitter64::PSUBW(REG_64 xmm_source, REG_64 xmm_dest)
 {
-    cache->write<uint8_t>(0x66);
+    block->write<uint8_t>(0x66);
     rex_r_rm(xmm_dest, xmm_source);
-    cache->write<uint8_t>(0x0F);
-    cache->write<uint8_t>(0xF9);
+    block->write<uint8_t>(0x0F);
+    block->write<uint8_t>(0xF9);
     modrm(0b11, xmm_dest, xmm_source);
 }
 
 void Emitter64::PSUBSB(REG_64 xmm_source, REG_64 xmm_dest)
 {
-    cache->write<uint8_t>(0x66);
+    block->write<uint8_t>(0x66);
     rex_r_rm(xmm_dest, xmm_source);
-    cache->write<uint8_t>(0x0F);
-    cache->write<uint8_t>(0xE8);
+    block->write<uint8_t>(0x0F);
+    block->write<uint8_t>(0xE8);
     modrm(0b11, xmm_dest, xmm_source);
 }
 
 void Emitter64::PSUBSW(REG_64 xmm_source, REG_64 xmm_dest)
 {
-    cache->write<uint8_t>(0x66);
+    block->write<uint8_t>(0x66);
     rex_r_rm(xmm_dest, xmm_source);
-    cache->write<uint8_t>(0x0F);
-    cache->write<uint8_t>(0xE9);
+    block->write<uint8_t>(0x0F);
+    block->write<uint8_t>(0xE9);
     modrm(0b11, xmm_dest, xmm_source);
 }
 
 void Emitter64::PSUBUSB(REG_64 xmm_source, REG_64 xmm_dest)
 {
-    cache->write<uint8_t>(0x66);
+    block->write<uint8_t>(0x66);
     rex_r_rm(xmm_dest, xmm_source);
-    cache->write<uint8_t>(0x0F);
-    cache->write<uint8_t>(0xD8);
+    block->write<uint8_t>(0x0F);
+    block->write<uint8_t>(0xD8);
     modrm(0b11, xmm_dest, xmm_source);
 }
 
 void Emitter64::PSUBUSW(REG_64 xmm_source, REG_64 xmm_dest)
 {
-    cache->write<uint8_t>(0x66);
+    block->write<uint8_t>(0x66);
     rex_r_rm(xmm_dest, xmm_source);
-    cache->write<uint8_t>(0x0F);
-    cache->write<uint8_t>(0xD9);
+    block->write<uint8_t>(0x0F);
+    block->write<uint8_t>(0xD9);
     modrm(0b11, xmm_dest, xmm_source);
 }
 
 void Emitter64::PXOR_XMM(REG_64 xmm_source, REG_64 xmm_dest)
 {
-    cache->write<uint8_t>(0x66);
+    block->write<uint8_t>(0x66);
     rex_r_rm(xmm_dest, xmm_source);
-    cache->write<uint8_t>(0x0F);
-    cache->write<uint8_t>(0xEF);
+    block->write<uint8_t>(0x0F);
+    block->write<uint8_t>(0xEF);
     modrm(0b11, xmm_dest, xmm_source);
 }
 
 void Emitter64::PXOR_XMM_FROM_MEM(REG_64 indir_source, REG_64 xmm_dest, uint32_t offset)
 {
-    cache->write<uint8_t>(0x66);
+    block->write<uint8_t>(0x66);
     rex_r_rm(xmm_dest, indir_source);
-    cache->write<uint8_t>(0x0F);
-    cache->write<uint8_t>(0xEF);
+    block->write<uint8_t>(0x0F);
+    block->write<uint8_t>(0xEF);
     modrm(0, xmm_dest, indir_source);
     if ((indir_source & 7) == 4)
-        cache->write<uint8_t>(0x24);
+        block->write<uint8_t>(0x24);
     if ((indir_source & 7) == 5 || offset)
-        cache->write<uint32_t>(offset);
+        block->write<uint32_t>(offset);
 }
 
 void Emitter64::ADDPS(REG_64 xmm_source, REG_64 xmm_dest)
 {
     rex_r_rm(xmm_dest, xmm_source);
-    cache->write<uint8_t>(0x0F);
-    cache->write<uint8_t>(0x58);
+    block->write<uint8_t>(0x0F);
+    block->write<uint8_t>(0x58);
     modrm(0b11, xmm_dest, xmm_source);
 }
 
 void Emitter64::ADDSS(REG_64 xmm_source, REG_64 xmm_dest)
 {
-    cache->write<uint8_t>(0xF3);
+    block->write<uint8_t>(0xF3);
     rex_r_rm(xmm_dest, xmm_source);
-    cache->write<uint8_t>(0x0F);
-    cache->write<uint8_t>(0x58);
+    block->write<uint8_t>(0x0F);
+    block->write<uint8_t>(0x58);
     modrm(0b11, xmm_dest, xmm_source);
 }
 
 void Emitter64::BLENDPS(uint8_t imm, REG_64 xmm_source, REG_64 xmm_dest)
 {
-    cache->write<uint8_t>(0x66);
+    block->write<uint8_t>(0x66);
     rex_r_rm(xmm_dest, xmm_source);
-    cache->write<uint8_t>(0x0F);
-    cache->write<uint8_t>(0x3A);
-    cache->write<uint8_t>(0x0C);
+    block->write<uint8_t>(0x0F);
+    block->write<uint8_t>(0x3A);
+    block->write<uint8_t>(0x0C);
     modrm(0b11, xmm_dest, xmm_source);
-    cache->write<uint8_t>(imm);
+    block->write<uint8_t>(imm);
 }
 
 void Emitter64::CMPEQPS(REG_64 xmm_source, REG_64 xmm_dest)
 {
     rex_r_rm(xmm_dest, xmm_source);
-    cache->write<uint8_t>(0x0F);
-    cache->write<uint8_t>(0xC2);
+    block->write<uint8_t>(0x0F);
+    block->write<uint8_t>(0xC2);
     modrm(0b11, xmm_dest, xmm_source);
-    cache->write<uint8_t>(0x00);
+    block->write<uint8_t>(0x00);
 }
 
 void Emitter64::CMPNLEPS(REG_64 xmm_source, REG_64 xmm_dest)
 {
     rex_r_rm(xmm_dest, xmm_source);
-    cache->write<uint8_t>(0x0F);
-    cache->write<uint8_t>(0xC2);
+    block->write<uint8_t>(0x0F);
+    block->write<uint8_t>(0xC2);
     modrm(0b11, xmm_dest, xmm_source);
-    cache->write<uint8_t>(0x06);
+    block->write<uint8_t>(0x06);
 }
 
 void Emitter64::DIVPS(REG_64 xmm_source, REG_64 xmm_dest)
 {
     rex_r_rm(xmm_dest, xmm_source);
-    cache->write<uint8_t>(0x0F);
-    cache->write<uint8_t>(0x5E);
+    block->write<uint8_t>(0x0F);
+    block->write<uint8_t>(0x5E);
     modrm(0b11, xmm_dest, xmm_source);
 }
 
 void Emitter64::DIVSS(REG_64 xmm_source, REG_64 xmm_dest)
 {
-    cache->write<uint8_t>(0xF3);
+    block->write<uint8_t>(0xF3);
     rex_r_rm(xmm_dest, xmm_source);
-    cache->write<uint8_t>(0x0F);
-    cache->write<uint8_t>(0x5E);
+    block->write<uint8_t>(0x0F);
+    block->write<uint8_t>(0x5E);
     modrm(0b11, xmm_dest, xmm_source);
 }
 
 void Emitter64::DPPS(uint8_t imm, REG_64 xmm_source, REG_64 xmm_dest)
 {
-    cache->write<uint8_t>(0x66);
+    block->write<uint8_t>(0x66);
     rex_r_rm(xmm_dest, xmm_source);
-    cache->write<uint8_t>(0x0F);
-    cache->write<uint8_t>(0x3A);
-    cache->write<uint8_t>(0x40);
+    block->write<uint8_t>(0x0F);
+    block->write<uint8_t>(0x3A);
+    block->write<uint8_t>(0x40);
     modrm(0b11, xmm_dest, xmm_source);
-    cache->write<uint8_t>(imm);
+    block->write<uint8_t>(imm);
 }
 
 void Emitter64::INSERTPS(uint8_t count_s, uint8_t count_d, uint8_t zmask, REG_64 xmm_source, REG_64 xmm_dest)
 {
-    cache->write<uint8_t>(0x66);
+    block->write<uint8_t>(0x66);
     rex_r_rm(xmm_dest, xmm_source);
-    cache->write<uint8_t>(0x0F);
-    cache->write<uint8_t>(0x3A);
-    cache->write<uint8_t>(0x21);
+    block->write<uint8_t>(0x0F);
+    block->write<uint8_t>(0x3A);
+    block->write<uint8_t>(0x21);
     modrm(0b11, xmm_dest, xmm_source);
 
     uint8_t imm = (count_s & 0x3) << 6;
     imm |= (count_d & 0x3) << 4;
     imm |= zmask & 0xF;
-    cache->write<uint8_t>(imm);
+    block->write<uint8_t>(imm);
 }
 
 void Emitter64::MAXPS(REG_64 xmm_source, REG_64 xmm_dest)
 {
     rex_r_rm(xmm_dest, xmm_source);
-    cache->write<uint8_t>(0x0F);
-    cache->write<uint8_t>(0x5F);
+    block->write<uint8_t>(0x0F);
+    block->write<uint8_t>(0x5F);
     modrm(0b11, xmm_dest, xmm_source);
 }
 
 void Emitter64::MAXSS(REG_64 xmm_source, REG_64 xmm_dest)
 {
-    cache->write<uint8_t>(0xF3);
+    block->write<uint8_t>(0xF3);
     rex_r_rm(xmm_dest, xmm_source);
-    cache->write<uint8_t>(0x0F);
-    cache->write<uint8_t>(0x5F);
+    block->write<uint8_t>(0x0F);
+    block->write<uint8_t>(0x5F);
     modrm(0b11, xmm_dest, xmm_source);
 }
 
 void Emitter64::MINPS(REG_64 xmm_source, REG_64 xmm_dest)
 {
     rex_r_rm(xmm_dest, xmm_source);
-    cache->write<uint8_t>(0x0F);
-    cache->write<uint8_t>(0x5D);
+    block->write<uint8_t>(0x0F);
+    block->write<uint8_t>(0x5D);
     modrm(0b11, xmm_dest, xmm_source);
 }
 
 void Emitter64::MINSS(REG_64 xmm_source, REG_64 xmm_dest)
 {
-    cache->write<uint8_t>(0xF3);
+    block->write<uint8_t>(0xF3);
     rex_r_rm(xmm_dest, xmm_source);
-    cache->write<uint8_t>(0x0F);
-    cache->write<uint8_t>(0x5D);
+    block->write<uint8_t>(0x0F);
+    block->write<uint8_t>(0x5D);
     modrm(0b11, xmm_dest, xmm_source);
 }
 
@@ -2251,148 +2249,148 @@ void Emitter64::MINSS(REG_64 xmm_source, REG_64 xmm_dest)
 void Emitter64::MULPS(REG_64 xmm_source, REG_64 xmm_dest)
 {
     rex_r_rm(xmm_dest, xmm_source);
-    cache->write<uint8_t>(0x0F);
-    cache->write<uint8_t>(0x59);
+    block->write<uint8_t>(0x0F);
+    block->write<uint8_t>(0x59);
     modrm(0b11, xmm_dest, xmm_source);
 }
 
 void Emitter64::MULSS(REG_64 xmm_source, REG_64 xmm_dest)
 {
-    cache->write<uint8_t>(0xF3);
+    block->write<uint8_t>(0xF3);
     rex_r_rm(xmm_dest, xmm_source);
-    cache->write<uint8_t>(0x0F);
-    cache->write<uint8_t>(0x59);
+    block->write<uint8_t>(0x0F);
+    block->write<uint8_t>(0x59);
     modrm(0b11, xmm_dest, xmm_source);
 }
 
 void Emitter64::SHUFPS(uint8_t imm, REG_64 xmm_source, REG_64 xmm_dest)
 {
     rex_r_rm(xmm_dest, xmm_source);
-    cache->write<uint8_t>(0x0F);
-    cache->write<uint8_t>(0xC6);
+    block->write<uint8_t>(0x0F);
+    block->write<uint8_t>(0xC6);
     modrm(0b11, xmm_dest, xmm_source);
-    cache->write<uint8_t>(imm);
+    block->write<uint8_t>(imm);
 }
 
 void Emitter64::SQRTSS(REG_64 xmm_source, REG_64 xmm_dest)
 {
-    cache->write<uint8_t>(0xF3);
+    block->write<uint8_t>(0xF3);
     rex_r_rm(xmm_dest, xmm_source);
-    cache->write<uint8_t>(0x0F);
-    cache->write<uint8_t>(0x51);
+    block->write<uint8_t>(0x0F);
+    block->write<uint8_t>(0x51);
     modrm(0b11, xmm_dest, xmm_source);
 }
 
 void Emitter64::SQRTPS(REG_64 xmm_source, REG_64 xmm_dest)
 {
     rex_r_rm(xmm_dest, xmm_source);
-    cache->write<uint8_t>(0x0F);
-    cache->write<uint8_t>(0x51);
+    block->write<uint8_t>(0x0F);
+    block->write<uint8_t>(0x51);
     modrm(0b11, xmm_dest, xmm_source);
 }
 
 void Emitter64::SUBPS(REG_64 xmm_source, REG_64 xmm_dest)
 {
     rex_r_rm(xmm_dest, xmm_source);
-    cache->write<uint8_t>(0x0F);
-    cache->write<uint8_t>(0x5C);
+    block->write<uint8_t>(0x0F);
+    block->write<uint8_t>(0x5C);
     modrm(0b11, xmm_dest, xmm_source);
 }
 
 void Emitter64::SUBSS(REG_64 xmm_source, REG_64 xmm_dest)
 {
-    cache->write<uint8_t>(0xF3);
+    block->write<uint8_t>(0xF3);
     rex_r_rm(xmm_dest, xmm_source);
-    cache->write<uint8_t>(0x0F);
-    cache->write<uint8_t>(0x5C);
+    block->write<uint8_t>(0x0F);
+    block->write<uint8_t>(0x5C);
     modrm(0b11, xmm_dest, xmm_source);
 }
 
 void Emitter64::RSQRTSS(REG_64 xmm_source, REG_64 xmm_dest)
 {
-    cache->write<uint8_t>(0xF3);
+    block->write<uint8_t>(0xF3);
     rex_r_rm(xmm_dest, xmm_source);
-    cache->write<uint8_t>(0x0F);
-    cache->write<uint8_t>(0x52);
+    block->write<uint8_t>(0x0F);
+    block->write<uint8_t>(0x52);
     modrm(0b11, xmm_dest, xmm_source);
 }
 
 void Emitter64::RSQRTPS(REG_64 xmm_source, REG_64 xmm_dest)
 {
     rex_r_rm(xmm_dest, xmm_source);
-    cache->write<uint8_t>(0x0F);
-    cache->write<uint8_t>(0x52);
+    block->write<uint8_t>(0x0F);
+    block->write<uint8_t>(0x52);
     modrm(0b11, xmm_dest, xmm_source);
 }
 
 void Emitter64::UCOMISS(REG_64 xmm_source, REG_64 xmm_dest)
 {
     rex_r_rm(xmm_dest, xmm_source);
-    cache->write<uint8_t>(0x0F);
-    cache->write<uint8_t>(0x2E);
+    block->write<uint8_t>(0x0F);
+    block->write<uint8_t>(0x2E);
     modrm(0b11, xmm_dest, xmm_source);
 }
 
 void Emitter64::XORPS(REG_64 xmm_source, REG_64 xmm_dest)
 {
     rex_r_rm(xmm_dest, xmm_source);
-    cache->write<uint8_t>(0x0F);
-    cache->write<uint8_t>(0x57);
+    block->write<uint8_t>(0x0F);
+    block->write<uint8_t>(0x57);
     modrm(0b11, xmm_dest, xmm_source);
 }
 
 void Emitter64::CVTDQ2PS(REG_64 xmm_source, REG_64 xmm_dest)
 {
     rex_r_rm(xmm_dest, xmm_source);
-    cache->write<uint8_t>(0x0F);
-    cache->write<uint8_t>(0x5B);
+    block->write<uint8_t>(0x0F);
+    block->write<uint8_t>(0x5B);
     modrm(0b11, xmm_dest, xmm_source);
 }
 
 void Emitter64::CVTSS2SI(REG_64 xmm_source, REG_64 int_dest)
 {
-    cache->write<uint8_t>(0xF3);
+    block->write<uint8_t>(0xF3);
     rex_r_rm(int_dest, xmm_source);
-    cache->write<uint8_t>(0x0F);
-    cache->write<uint8_t>(0x2D);
+    block->write<uint8_t>(0x0F);
+    block->write<uint8_t>(0x2D);
     modrm(0b11, int_dest, xmm_source);
 }
 
 void Emitter64::CVTSI2SS(REG_64 int_source, REG_64 xmm_dest)
 {
-    cache->write<uint8_t>(0xF3);
+    block->write<uint8_t>(0xF3);
     rex_r_rm(xmm_dest, int_source);
-    cache->write<uint8_t>(0x0F);
-    cache->write<uint8_t>(0x2A);
+    block->write<uint8_t>(0x0F);
+    block->write<uint8_t>(0x2A);
     modrm(0b11, xmm_dest, int_source);
 }
 
 void Emitter64::CVTTPS2DQ(REG_64 xmm_source, REG_64 xmm_dest)
 {
-    cache->write<uint8_t>(0xF3);
+    block->write<uint8_t>(0xF3);
     rex_r_rm(xmm_dest, xmm_source);
-    cache->write<uint8_t>(0x0F);
-    cache->write<uint8_t>(0x5B);
+    block->write<uint8_t>(0x0F);
+    block->write<uint8_t>(0x5B);
     modrm(0b11, xmm_dest, xmm_source);
 }
 
 void Emitter64::VADDSS(REG_64 xmm_source, REG_64 xmm_source2, REG_64 xmm_dest)
 {
     vex(xmm_source, xmm_source2, xmm_dest, false);
-    cache->write<uint8_t>(0x58);
+    block->write<uint8_t>(0x58);
     modrm(0b11, 0, xmm_source2);
 }
 
 void Emitter64::VMINPS(REG_64 xmm_source, REG_64 xmm_source2, REG_64 xmm_dest)
 {
     vex(xmm_source, xmm_source2, xmm_dest, true);
-    cache->write<uint8_t>(0x5D);
+    block->write<uint8_t>(0x5D);
     modrm(0b11, 0, xmm_source2);
 }
 
 void Emitter64::VMAXPS(REG_64 xmm_source, REG_64 xmm_source2, REG_64 xmm_dest)
 {
     vex(xmm_source, xmm_source2, xmm_dest, true);
-    cache->write<uint8_t>(0x5F);
+    block->write<uint8_t>(0x5F);
     modrm(0b11, 0, xmm_source2);
 }

--- a/src/core/jitcommon/emitter64.hpp
+++ b/src/core/jitcommon/emitter64.hpp
@@ -52,7 +52,7 @@ enum class ConditionCode
 class Emitter64
 {
     private:
-        JitCache* cache;
+        JitBlock* block;
 
         void rex_r(REG_64 reg);
         void rex_rm(REG_64 rm);
@@ -67,7 +67,7 @@ class Emitter64
 
         int get_rip_offset(uint64_t addr);
     public:
-        Emitter64(JitCache* cache);
+        Emitter64(JitBlock* cache);
 
         void load_addr(uint64_t addr, REG_64 dest);
 

--- a/src/core/jitcommon/jitcache.cpp
+++ b/src/core/jitcommon/jitcache.cpp
@@ -499,11 +499,14 @@ EEJitHeap::~EEJitHeap()
 EEPageRecord* EEJitHeap::lookup_ee_page(uint32_t page)
 {
     page_lookups++;
+
+    // try page lookup cache
     if(ee_page_lookup_idx == page) {
         cached_page_lookups++;
         return ee_page_lookup_cache;
     }
 
+    // otherwise do an actual lookup
     EEPageRecord* rec = &ee_page_record_map[page];
 
     ee_page_lookup_cache = rec;
@@ -512,59 +515,16 @@ EEPageRecord* EEJitHeap::lookup_ee_page(uint32_t page)
     return rec;
 }
 
-/*!
- * Free memory for a single block and remove it from the lookup.
- */
-void EEJitHeap::free_block(uint32_t PC) {
-    auto kv = blocks.find(PC);
-
-    if(kv == blocks.end())
-        return;
-
-    EEJitBlockRecord* block = &kv->second;
-
-    if(PC != block->block_data.pc) {
-        Errors::die("Mismatch between key and value state");
-    }
-
-    // update ee page linked list
-//    if(block->block_data.next) {
-//        block->block_data.next->block_data.prev = block->block_data.prev;
-//    }
-//
-//    if(block->block_data.prev) {
-//        block->block_data.prev->block_data.next = block->block_data.next;
-//    } else {
-//        // no prev means we were the head
-//        *get_ee_page_list_head(block->block_data.pc / 4096) = block->block_data.next;
-//    }
-
-    // free memory
-    jit_free(block->literals_start);
-
-    // remove from hash table
-    blocks.erase(kv);
-}
 
 /*!
  * Free memory for all blocks inside an EE page and remove them from the lookup.
  */
 void EEJitHeap::invalidate_ee_page(uint32_t page)
 {
-//    EEJitBlockRecord** head_ptr = get_ee_page_list_head(page);
-//    EEJitBlockRecord* block = *head_ptr;
-//
-//    while(block) {
-//        auto* next = block->block_data.next;
-//        jit_free(block->literals_start);
-//        blocks.erase(block->block_data.pc);
-//        block = next;
-//    }
-//
-//    *head_ptr = nullptr;
-
+    // check if page record exists
     auto kv = ee_page_record_map.find(page);
     if(kv != ee_page_record_map.end()) {
+        // kill all PCs in the page.
         if(kv->second.block_array) {
             for(uint32_t idx = 0; idx < 1024; idx++) {
                 if(kv->second.block_array[idx].literals_start) {
@@ -572,15 +532,19 @@ void EEJitHeap::invalidate_ee_page(uint32_t page)
                 }
             }
         }
+        // erase PC array
         delete[] kv->second.block_array;
+        // and record
         ee_page_record_map.erase(page);
     }
 
+    // invalidate cache if needed
     if(page == ee_page_lookup_idx) {
         ee_page_lookup_cache = nullptr;
         ee_page_lookup_idx = -1;
     }
 
+    // print stats.
     invalid_count++;
     if(invalid_count == 10000) {
         invalid_count = 0;
@@ -595,13 +559,6 @@ void EEJitHeap::invalidate_ee_page(uint32_t page)
  */
 EEJitBlockRecord* EEJitHeap::find_block(uint32_t PC)
 {
-//    auto kv = blocks.find(PC);
-//    if(kv != blocks.end())
-//    {
-//        return &(kv->second);
-//    }
-//    return nullptr;
-
     uint32_t page = PC / 4096;
     uint64_t idx = (PC - 4096*page)/4;
     EEPageRecord* page_rec = lookup_ee_page(page);
@@ -611,28 +568,12 @@ EEJitBlockRecord* EEJitHeap::find_block(uint32_t PC)
     return nullptr;
 }
 
-bool EEJitHeap::is_page_valid(uint32_t page) {
-    EEPageRecord* page_rec = lookup_ee_page(page);
-    return page_rec->valid;
-}
 
 /*!
  * Completely flush the heap
  */
 void EEJitHeap::flush_all_blocks()
 {
-
-//    for (auto &it : blocks)
-//    {
-//        EEJitBlockRecord *block = &it.second;
-//        jit_free(block->literals_start);
-//    }
-//
-//    // todo heap check here?
-//
-//    ee_page_lists.clear();
-//    blocks.clear();
-
     for(auto& page : ee_page_record_map)
     {
         for(uint32_t idx = 0; idx < 1024; idx++)
@@ -698,46 +639,8 @@ EEJitBlockRecord* EEJitHeap::insert_block(uint32_t PC, JitBlock *block)
     }
 
 
-    // add to hash table
-//    auto it = blocks.insert({PC, record}).first;
-
-    // ee page lists
-//    EEJitBlockRecord** page_list_head = get_ee_page_list_head(PC / 4096);
-//    it->second.block_data.next = *page_list_head;
-//    it->second.block_data.prev = nullptr;
-//
-//    if(it->second.block_data.next) {
-//        it->second.block_data.next->block_data.prev = &it->second;
-//    }
-//    *page_list_head = &it->second;
-//    return &it->second;
-
     uint64_t idx = (PC - 4096*page)/4;
     assert(idx < 1024);
     page_record->block_array[idx] = record;
     return &page_record->block_array[idx];
-}
-
-///*!
-// * Returns a pointer to the head of the ee page list
-// */
-//EEJitBlockRecord** EEJitHeap::get_ee_page_list_head(uint32_t ee_page)
-//{
-//    auto kv = ee_page_lists.find(ee_page);
-//    if(kv == ee_page_lists.end()) {
-//        // doesn't exist yet, add it
-//        ee_page_lists[ee_page] = nullptr;
-//        return &ee_page_lists.find(ee_page)->second;
-//    } else {
-//        return &kv->second;
-//    }
-//}
-
-void EEJitHeap::debug_print_page_list(uint32_t ee_page)
-{
-    printf("PAGE LIST\n");
-//    for(EEJitBlockRecord* block = *get_ee_page_list_head(ee_page); block; block = block->block_data.next) {
-//        printf("dbg [0x%x] 0x%lx n: 0x%lx p: 0x%lx\n", block->block_data.pc, (uint64_t)block,
-//            (uint64_t)block->block_data.next, (uint64_t)block->block_data.prev);
-//    }
 }

--- a/src/core/jitcommon/jitcache.cpp
+++ b/src/core/jitcommon/jitcache.cpp
@@ -13,256 +13,74 @@
 #include "../errors.hpp"
 #include "jitcache.hpp"
 
-// JIT Cache Design
-//
-//
-// JIT blocks are built inside a temporary area of size MAX_CODE + MAX_LITERALS
-//   the code starts at offset MAX_LITERALS and grows forward
-//   the literals start at offset MAX_LITERALS and grows backward
-//
-// Once a JIT block is completed, space is allocated on the JIT heap (for exactly the needed code/literal size)
-//   and the block is copied to the heap.  To get JIT heap memory, you must use jit_malloc and jit_free.
-//
-// JIT block records are part of a linked list of all the jit blocks in a given ee page.  When invalidating an EE page
-//  this linked list is used to determine all blocks to be flushed.
-//
-//
+//////////////
+// JIT Block
+//////////////
 
+JitBlock::JitBlock(const std::string &name) {
+    jit_name = name;
 
-/*!
- * Allocate all memory for a JIT cache.  Currently, all memory is marked RWX, which is unsafe.
- * If size is 0, use default size.
- */
-JitCache::JitCache(std::size_t size)
-{
-
-  // set JIT heap size
-  if(!size)
-    size = JIT_CACHE_DEFAULT_SIZE;
-  _heap_size = size;
-
-  // allocate JIT heap
-#ifdef _WIN32
-    _heap = (void *)VirtualAlloc(NULL, _heap_size, MEM_COMMIT | MEM_RESERVE, PAGE_EXECUTE_READWRITE);
-#else
-  _heap = (void*)mmap(nullptr, _heap_size, PROT_READ | PROT_WRITE | PROT_EXEC, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
-#endif
-
-  if(!_heap)
-    Errors::die("[JIT] Unable to allocate block");
-
-  // allocator setup
-  init_allocator();
-
-  // scratch storage for block being build
-  // the code starts at block + MAX_LITERALSIZE and grows forward
-  // the literals start at block + MAX_LITERALSIZE and grow backward
-  // this way literals/code end up back to back, and we can allocate space just for the
-  // needed code/literals
-  building_block = new uint8_t[JIT_MAX_BLOCK_CODESIZE + JIT_MAX_BLOCK_LITERALSIZE];
-
-  // block that was allocated/found most recently
-  current_block = nullptr;
+    // scratch storage for block being build
+    // the code starts at block + MAX_LITERALSIZE and grows forward
+    // the literals start at block + MAX_LITERALSIZE and grow backward
+    // this way literals/code end up back to back, and we can allocate space just for the
+    // needed code/literals
+    building_block = new uint8_t[JIT_MAX_BLOCK_CODESIZE + JIT_MAX_BLOCK_LITERALSIZE];
+    clear();
 }
 
 
 /*!
  * Free the JIT cache heap and scratch memory
  */
-JitCache::~JitCache()
+JitBlock::~JitBlock()
 {
-#ifdef _WIN32
-  VirtualFree(_heap, 0, MEM_RELEASE);
-#else
-  munmap(_heap, _heap_size);
-#endif
-
   delete[] building_block;
 }
 
-
-
 /*!
- * Start creating a new jit block.
- * This block will live in the building_block (not on JIT heap) until it is finished
+ * Reset a JitBlock to empty.
  */
-void JitCache::alloc_block(BlockState state)
-{
-  // prepare jit block record to point to the scratch block
-  building_jit_block.code_start = building_block + JIT_MAX_BLOCK_LITERALSIZE;
-  building_jit_block.code_end = building_jit_block.code_start;
-  building_jit_block.literals_start = building_jit_block.code_start;
-  building_jit_block.state = state;
-
-  // set scratch block as current block
-  current_block = &building_jit_block;
-}
-
-/*!
- * Free a JIT block which has been allocated.
- * If there is no block with the state, does nothing.
- */
-void JitCache::free_block(BlockState state)
-{
-  auto kv = blocks.find(state);
-
-  if(kv == blocks.end())
-    return;
-
-  JitBlock* block = &kv->second;
-
-  if(!(state == block->state)) {
-    Errors::die("Mismatch between key and value state");
-  }
-
-  // update ee page linked list
-  if(block->next) {
-    block->next->prev = block->prev;
-  }
-
-  if(block->prev) {
-    block->prev->next = block->next;
-  } else {
-    // no prev means we were the head
-    *get_ee_page_list_head(block->state.pc / 4096) = block->next;
-  }
-
-  // free memory
-  jit_free(block->literals_start);
-
-  // remove from hash table
-  blocks.erase(kv);
-}
-
-/*!
- * Invalidate an entire EE page worth of blocks.
- */
-void JitCache::invalidate_ee_page(uint32_t page)
-{
-  JitBlock** head_ptr = get_ee_page_list_head(page);
-  JitBlock* block = *head_ptr;
-
-  while(block) {
-    auto* next = block->next;
-    jit_free(block->literals_start);
-    blocks.erase(block->state); // bleh
-    block = next;
-  }
-
-  *head_ptr = nullptr;
-}
-
-/*!
- * Return a matching block and set current_block
- * returns/sets nullptr if the block isn't found.
- */
-JitBlock* JitCache::find_block(BlockState state)
-{
-  auto kv = blocks.find(state);
-  if(kv != blocks.end())
-  {
-    current_block = &(kv->second);
-    return current_block;
-  }
-  current_block = nullptr;
-  return nullptr;
+void JitBlock::clear() {
+    code_start = building_block + JIT_MAX_BLOCK_LITERALSIZE;
+    code_end = code_start;
+    literals_start = code_start;
 }
 
 /*!
  * Get the start of the current block's code
  */
-uint8_t* JitCache::get_current_block_start()
+uint8_t* JitBlock::get_code_start()
 {
-  return (uint8_t*)current_block->code_start;
+    return (uint8_t*)code_start;
 }
 
 /*!
  * Get the current position of the code pointer
  */
-uint8_t* JitCache::get_current_block_pos()
+uint8_t* JitBlock::get_code_pos()
 {
-  return (uint8_t*)current_block->code_end;
+    return (uint8_t*)code_end;
+}
+
+uint8_t* JitBlock::get_literals_start()
+{
+    return (uint8_t*)literals_start;
 }
 
 /*!
  * Set the position of the code pointer
  */
-void JitCache::set_current_block_pos(uint8_t *pos)
+void JitBlock::set_code_pos(uint8_t *pos)
 {
-  current_block->code_end = pos;
+    code_end = pos;
 }
 
 
-/*!
- * Finalize a block and mark it as exectuable.
- * This copies the block to the JIT heap
- */
-void JitCache::set_current_block_rx()
+void JitBlock::print_block()
 {
-  if(current_block != &building_jit_block) Errors::die("Tried to set rx a block that is not in progress");
-  std::size_t block_size = (uint8_t*)current_block->code_end - (uint8_t*)current_block->literals_start;
-  if(block_size <= 0) Errors::die("block size invalid");
-
-  // allocate space on JIT heap
-  void* dest = jit_malloc(block_size);
-
-  if(!dest) {
-    fprintf(stderr, "Flushing JIT cache\n");
-    flush_all_blocks();
-    current_block = &building_jit_block;
-    dest = jit_malloc(block_size);
-  }
-  if(!dest) {
-    Errors::die("JIT heap out of memory even after freeing all, something is wrong with the jit allocator");
-  }
-
-
-  // copy to heap
-  std::memcpy(dest, current_block->literals_start, block_size);
-
-  // update record to point to jit heap
-  std::size_t literal_size = (uint8_t*)building_jit_block.code_start - (uint8_t*)building_jit_block.literals_start;
-  std::size_t code_size = (uint8_t*)building_jit_block.code_end - (uint8_t*)building_jit_block.code_start;
-  building_jit_block.literals_start = dest;
-  building_jit_block.code_start = (uint8_t*)building_jit_block.literals_start + literal_size;
-  building_jit_block.code_end = (uint8_t*)building_jit_block.code_start + code_size;
-
-  // add record to hash table
-  auto it = blocks.insert({building_jit_block.state, building_jit_block}).first;
-
-  // push onto ee page list
-  JitBlock** page_list_head = get_ee_page_list_head(building_jit_block.state.pc / 4096);
-  it->second.next = *page_list_head;
-  it->second.prev = nullptr;
-  if(it->second.next) {
-    it->second.next->prev = &it->second;
-  }
-  *page_list_head = &it->second;
-}
-
-/*!
- * Completely flush the JIT cache
- */
-void JitCache::flush_all_blocks()
-{
-  current_block = nullptr;
-
-  for (auto &it : blocks)
-  {
-    JitBlock *block = &it.second;
-    jit_free(block->literals_start);
-  }
-
-  // todo heap check here?
-
-  ee_page_lists.clear();
-  blocks.clear();
-}
-
-void JitCache::print_current_block()
-{
-  auto* ptr = (uint8_t*)current_block->code_start;
-  auto* end = (uint8_t*)current_block->code_end;
+  auto* ptr = (uint8_t*)code_start;
+  auto* end = (uint8_t*)code_end;
   printf("[JIT Cache] Block: ");
   while (ptr != end)
   {
@@ -272,10 +90,10 @@ void JitCache::print_current_block()
   printf("\n");
 }
 
-void JitCache::print_literal_pool()
+void JitBlock::print_literal_pool()
 {
-  auto* ptr = (uint8_t*)current_block->literals_start;
-  auto* end = (uint8_t*)current_block->code_start;
+  auto* ptr = (uint8_t*)literals_start;
+  auto* end = (uint8_t*)code_start;
   int offset = 0;
   while(ptr != end) {
     printf("$%02X ", *ptr);
@@ -286,28 +104,33 @@ void JitCache::print_literal_pool()
   }
 }
 
-/*!
- * Returns a pointer to the head of the ee page list
- */
-JitBlock** JitCache::get_ee_page_list_head(uint32_t ee_page)
+
+////////////////////
+// JIT Heap Common
+///////////////////
+
+
+void* JitHeap::rwx_alloc(std::size_t size)
 {
-  auto kv = ee_page_lists.find(ee_page);
-  if(kv == ee_page_lists.end()) {
-    // doesn't exist yet, add it
-    ee_page_lists[ee_page] = nullptr;
-    return &ee_page_lists.find(ee_page)->second;
-  } else {
-    return &kv->second;
-  }
+    void* result;
+#ifdef _WIN32
+    result = (void *)VirtualAlloc(NULL, size, MEM_COMMIT | MEM_RESERVE, PAGE_EXECUTE_READWRITE);
+#else
+    result = (void*)mmap(nullptr, size, PROT_READ | PROT_WRITE | PROT_EXEC, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+#endif
+    return result;
 }
 
-void JitCache::debug_print_page_list(uint32_t ee_page)
+void JitHeap::rwx_free(void* mem, std::size_t size)
 {
-  printf("PAGE LIST\n");
-  for(JitBlock* block = *get_ee_page_list_head(ee_page); block; block = block->next) {
-    printf("dbg [0x%x] 0x%lx n: 0x%lx p: 0x%lx\n", block->state.pc, (uint64_t)block, (uint64_t)block->next, (uint64_t)block->prev);
-  }
+#ifdef _WIN32
+    VirtualFree(mem, 0, MEM_RELEASE);
+#else
+    munmap(mem, size);
+#endif
 }
+
+
 
 /////////////////
 // ALLOCATOR   //
@@ -356,7 +179,7 @@ static void* ptr_add(void* mem, std::size_t offset) {
 /*!
  * Get the minimum possible size of something in the nth bin.
  */
-std::size_t JitCache::get_min_bin_size(uint8_t bin)
+std::size_t EEJitHeap::get_min_bin_size(uint8_t bin)
 {
   assert(bin < JIT_ALLOC_BINS);
   return ((std::size_t)1 << (JIT_ALLOC_BIN_START + bin));
@@ -365,7 +188,7 @@ std::size_t JitCache::get_min_bin_size(uint8_t bin)
 /*!
  * Get the maximum possible size of something in the nth bin.
  */
-std::size_t JitCache::get_max_bin_size(uint8_t bin)
+std::size_t EEJitHeap::get_max_bin_size(uint8_t bin)
 {
   assert(bin < JIT_ALLOC_BINS);
   return ((std::size_t)1 << (JIT_ALLOC_BIN_START + bin + 1));
@@ -374,7 +197,7 @@ std::size_t JitCache::get_max_bin_size(uint8_t bin)
 /*!
  * Get the pointer to an object's size field. (at obj - 8)
  */
-std::size_t* JitCache::get_size_ptr(void *obj)
+std::size_t* EEJitHeap::get_size_ptr(void *obj)
 {
   auto *m = (std::size_t*)obj;
   return m - 1;
@@ -383,7 +206,7 @@ std::size_t* JitCache::get_size_ptr(void *obj)
 /*!
  * Get the pointer to an object's end field (at obj + size)
  */
-std::size_t* JitCache::get_end_ptr(void *obj)
+std::size_t* EEJitHeap::get_end_ptr(void *obj)
 {
   std::size_t size = *get_size_ptr(obj);
   assert(!(size & (JIT_ALLOC_ALIGN - 1))); // should be an aligned size
@@ -393,7 +216,7 @@ std::size_t* JitCache::get_end_ptr(void *obj)
 /*!
  * Get the object which occurs next in memory (at obj + size + sizeof(size_t))
  */
-void* JitCache::get_next_object(void *obj)
+void* EEJitHeap::get_next_object(void *obj)
 {
   return ptr_add(obj, *get_size_ptr(obj) + 2 * sizeof(std::size_t));
 }
@@ -401,7 +224,7 @@ void* JitCache::get_next_object(void *obj)
 /*!
  * Return memory to a bin
  */
-void JitCache::add_freed_memory_to_bin(void *mem)
+void EEJitHeap::add_freed_memory_to_bin(void *mem)
 {
   // pick bin
   std::size_t size = *get_size_ptr(mem);
@@ -434,7 +257,7 @@ void JitCache::add_freed_memory_to_bin(void *mem)
 /*!
  * Remove memory from a bin.
  */
-void JitCache::remove_memory_from_bin(void *mem)
+void EEJitHeap::remove_memory_from_bin(void *mem)
 {
   assert(*get_end_ptr(mem) == *get_size_ptr(mem));
 
@@ -462,7 +285,7 @@ void JitCache::remove_memory_from_bin(void *mem)
  * Reduce the size of an object and free memory if possible.
  * This works by splitting the object in two, then freeing the second one
  */
-void JitCache::shrink_object(void *obj, std::size_t size)
+void EEJitHeap::shrink_object(void *obj, std::size_t size)
 {
   assert(!*get_end_ptr(obj));
   assert(*get_size_ptr(obj) >= size);
@@ -485,7 +308,7 @@ void JitCache::shrink_object(void *obj, std::size_t size)
 /*!
  * Find memory of at least the given size.
  */
-void* JitCache::find_memory(std::size_t size)
+void* EEJitHeap::find_memory(std::size_t size)
 {
   // find smallest bin which contains chunks large enough for our object
   uint8_t bin = JIT_ALLOC_BINS;
@@ -544,7 +367,7 @@ void* JitCache::find_memory(std::size_t size)
  * Attempt to merge current block with the block in front.
  * Returns true if there might be more work to do
  */
-bool JitCache::merge_fwd(void *mem)
+bool EEJitHeap::merge_fwd(void *mem)
 {
   void* next = get_next_object(mem);
 
@@ -574,7 +397,7 @@ bool JitCache::merge_fwd(void *mem)
  * Attempt to merge current block with block behind.
  * Returns true if there might be more work to do
  */
-bool JitCache::merge_bwd(void *mem)
+bool EEJitHeap::merge_bwd(void *mem)
 {
   std::size_t* b_start = get_size_ptr(mem);
   std::size_t* a_end = b_start - 1;
@@ -601,7 +424,7 @@ bool JitCache::merge_bwd(void *mem)
 /*!
  * Initialize the JIT allocator
  */
-void JitCache::init_allocator()
+void EEJitHeap::init_allocator()
 {
   // all free lists start empty...
   for(auto& bin_list : free_bin_lists)
@@ -623,7 +446,7 @@ void JitCache::init_allocator()
 /*!
  * Free memory and merge blocks
  */
-void JitCache::jit_free(void *ptr)
+void EEJitHeap::jit_free(void *ptr)
 {
   assert(*get_size_ptr(ptr) <= heap_usage);
   heap_usage -= *get_size_ptr(ptr);
@@ -636,7 +459,7 @@ void JitCache::jit_free(void *ptr)
 /*!
  * Allocate memory
  */
-void* JitCache::jit_malloc(std::size_t size)
+void* EEJitHeap::jit_malloc(std::size_t size)
 {
   size = std::max(get_min_bin_size(0), aligned_size(size));
   if(size < sizeof(FreeList)) size = sizeof(FreeList);
@@ -645,4 +468,188 @@ void* JitCache::jit_malloc(std::size_t size)
     heap_usage += *get_size_ptr(mem); // this is the aligned size.  for tiny blocks they use 
   //fprintf(stderr, "mem %ld / %ld (%.2f pct)\n", heap_usage, _heap_size, 100. * (double)heap_usage / (double)_heap_size);
   return mem;
+}
+
+
+
+
+EEJitHeap::EEJitHeap()
+{
+    _heap_size = EE_JIT_HEAP_SIZE;
+
+    // allocate heap
+    _heap = rwx_alloc(_heap_size);
+
+    if(!_heap)
+        Errors::die("[EE JIT Heap] Unable to allocate heap");
+
+    // allocator setup
+    init_allocator();
+}
+
+EEJitHeap::~EEJitHeap()
+{
+    rwx_free(_heap, _heap_size);
+}
+
+/*!
+ * Free memory for a single block and remove it from the lookup.
+ */
+void EEJitHeap::free_block(uint32_t PC) {
+    auto kv = blocks.find(PC);
+
+    if(kv == blocks.end())
+        return;
+
+    EEJitBlockRecord* block = &kv->second;
+
+    if(PC != block->block_data.pc) {
+        Errors::die("Mismatch between key and value state");
+    }
+
+    // update ee page linked list
+    if(block->block_data.next) {
+        block->block_data.next->block_data.prev = block->block_data.prev;
+    }
+
+    if(block->block_data.prev) {
+        block->block_data.prev->block_data.next = block->block_data.next;
+    } else {
+        // no prev means we were the head
+        *get_ee_page_list_head(block->block_data.pc / 4096) = block->block_data.next;
+    }
+
+    // free memory
+    jit_free(block->literals_start);
+
+    // remove from hash table
+    blocks.erase(kv);
+}
+
+/*!
+ * Free memory for all blocks inside an EE page and remove them from the lookup.
+ */
+void EEJitHeap::invalidate_ee_page(uint32_t page)
+{
+    EEJitBlockRecord** head_ptr = get_ee_page_list_head(page);
+    EEJitBlockRecord* block = *head_ptr;
+
+    while(block) {
+        auto* next = block->block_data.next;
+        jit_free(block->literals_start);
+        blocks.erase(block->block_data.pc);
+        block = next;
+    }
+
+    *head_ptr = nullptr;
+}
+
+/*!
+ * Return a matching block
+ * returns nullptr if the block isn't found.
+ */
+EEJitBlockRecord* EEJitHeap::find_block(uint32_t PC)
+{
+    auto kv = blocks.find(PC);
+    if(kv != blocks.end())
+    {
+        return &(kv->second);
+    }
+    return nullptr;
+}
+
+/*!
+ * Completely flush the heap
+ */
+void EEJitHeap::flush_all_blocks()
+{
+
+    for (auto &it : blocks)
+    {
+        EEJitBlockRecord *block = &it.second;
+        jit_free(block->literals_start);
+    }
+
+    // todo heap check here?
+
+    ee_page_lists.clear();
+    blocks.clear();
+}
+
+/*!
+ * Add a completed block to the JIT heap
+ */
+EEJitBlockRecord* EEJitHeap::insert_block(uint32_t PC, JitBlock *block)
+{
+    // compute block size
+    uint8_t *code_start = block->get_code_start();
+    uint8_t *code_end = block->get_code_pos();
+    uint8_t *literals_start = block->get_literals_start();
+    std::size_t block_size = code_end - literals_start;
+    if(block_size <= 0) Errors::die("block size invalid");
+
+    // allocate space on JIT heap
+    void* dest = jit_malloc(block_size);
+
+    if(!dest)
+    {
+        fprintf(stderr, "JIT Heap is full. Flushing!\n");
+        flush_all_blocks();
+        dest = jit_malloc(block_size);
+    }
+
+    if(!dest)
+    {
+        Errors::die("JIT EE Heap memory error.  Either the heap is corrupted, or you are attempting to insert a block"
+                    "which is larger than the entire heap size.");
+    }
+
+    std::memcpy(dest, block->get_literals_start(), block_size);
+
+    // create a record
+    EEJitBlockRecord record;
+    std::size_t literal_size = code_start - literals_start;
+    std::size_t code_size = code_end - code_start;
+    record.literals_start = (uint8_t*)dest;
+    record.code_start = (uint8_t*)dest + literal_size;
+    record.code_end = (uint8_t*)dest + literal_size + code_size;
+    record.block_data.pc = PC;
+
+    // add to hash table
+    auto it = blocks.insert({PC, record}).first;
+
+    // ee page lists
+    EEJitBlockRecord** page_list_head = get_ee_page_list_head(PC / 4096);
+    it->second.block_data.next = *page_list_head;
+    it->second.block_data.prev = nullptr;
+
+    if(it->second.block_data.next) {
+        it->second.block_data.next->block_data.prev = &it->second;
+    }
+    *page_list_head = &it->second;
+    return &it->second;
+}
+
+/*!
+ * Returns a pointer to the head of the ee page list
+ */
+EEJitBlockRecord** EEJitHeap::get_ee_page_list_head(uint32_t ee_page)
+{
+    auto kv = ee_page_lists.find(ee_page);
+    if(kv == ee_page_lists.end()) {
+        // doesn't exist yet, add it
+        ee_page_lists[ee_page] = nullptr;
+        return &ee_page_lists.find(ee_page)->second;
+    } else {
+        return &kv->second;
+    }
+}
+
+void EEJitHeap::debug_print_page_list(uint32_t ee_page)
+{
+    printf("PAGE LIST\n");
+    for(EEJitBlockRecord* block = *get_ee_page_list_head(ee_page); block; block = block->block_data.next) {
+        printf("dbg [0x%x] 0x%lx n: 0x%lx p: 0x%lx\n", block->block_data.pc, (uint64_t)block,
+            (uint64_t)block->block_data.next, (uint64_t)block->block_data.prev);
+    }
 }

--- a/src/core/jitcommon/jitcache.hpp
+++ b/src/core/jitcommon/jitcache.hpp
@@ -1,171 +1,219 @@
 #ifndef JITCACHE_HPP
 #define JITCACHE_HPP
+
 #include <unordered_map>
 #include "../errors.hpp"
 
-struct BlockState
-{
-    public:
-        BlockState(uint32_t pc, uint32_t prev_pc, uint32_t program, uint64_t param1,
-                   uint64_t param2) : pc(pc), prev_pc(prev_pc), program(program),
-                   param1(param1), param2(param2) { }
-        BlockState() = default;
-        uint32_t pc;
-        uint32_t prev_pc = 0;
-        uint32_t program = 0;
-        uint64_t param1 = 0;
-        uint64_t param2 = 0;
+// New Stuff
 
-        // operator== is required to compare keys in case of hash collision
-        bool operator==(const BlockState &p) const
-        {
-            return pc == p.pc && prev_pc == p.prev_pc && program == p.program && param1 == p.param1 && param2 == p.param2;
+
+//struct BlockState
+//{
+//    public:
+//        BlockState(uint32_t pc, uint32_t prev_pc, uint32_t program, uint64_t param1,
+//                   uint64_t param2) : pc(pc), prev_pc(prev_pc), program(program),
+//                   param1(param1), param2(param2) { }
+//        BlockState() = default;
+//        uint32_t pc;
+//        uint32_t prev_pc = 0;
+//        uint32_t program = 0;
+//        uint64_t param1 = 0;
+//        uint64_t param2 = 0;
+//
+//        // operator== is required to compare keys in case of hash collision
+//        bool operator==(const BlockState &p) const
+//        {
+//            return pc == p.pc && prev_pc == p.prev_pc && program == p.program && param1 == p.param1 && param2 == p.param2;
+//        }
+//};
+//
+//struct BlockStateHash
+//{
+//    std::size_t operator()(const BlockState& state) const
+//    {
+//        std::size_t h1 = std::hash<uint32_t>()(state.pc);
+//        std::size_t h2 = std::hash<uint32_t>()(state.prev_pc);
+//        std::size_t h3 = std::hash<uint64_t>()(state.program);
+//        std::size_t h4 = std::hash<uint64_t>()(state.param1);
+//        std::size_t h5 = std::hash<uint64_t>()(state.param2);
+//
+//        std::size_t result = 0;
+//        std::size_t seed = 12345;
+//
+//        result = (result * seed) + h1;
+//        result = (result * seed) + h2;
+//        result = (result * seed) + h3;
+//        result = (result * seed) + h4;
+//        result = (result * seed) + h5;
+//
+//        return result;
+//    }
+//};
+
+
+/*!
+ * A record to keep track of JIT blocks. Points to the x86 code/literals, as well as some block_data
+ * which can be specialized for the specific JIT to contain state information and lookup data structures
+ */
+template<typename T>
+struct JitBlockRecord {
+    void *literals_start;
+    void *code_start;
+    void *code_end;
+    T block_data;
+};
+
+
+/*!
+ * Block of x86 code used in EE/VU/draw_pixel/texture JITs
+ */
+class JitBlock {
+private:
+    // old version had at most 8192 blocks, each 64 kB. this is quite large, let's do 1/128th of it.
+    // all these must have at least 16 byte alignment (or whatever JIT_ALLOC_ALIGN is set to).
+    constexpr static int JIT_MAX_BLOCK_CODESIZE = 1024 * 4096; // 512 kB/block maximum size
+    constexpr static int JIT_MAX_BLOCK_LITERALSIZE = 1024 * 8;
+    uint8_t *building_block = nullptr;
+    void *literals_start = nullptr;
+    void *code_start = nullptr;
+    void *code_end = nullptr;
+    std::string jit_name;
+
+public:
+    explicit JitBlock(const std::string &name);
+    ~JitBlock();
+    void clear();
+
+    uint8_t *get_code_start();
+    uint8_t *get_code_pos();
+    uint8_t *get_literals_start();
+    void set_code_pos(uint8_t *pos);
+    void print_block();
+    void print_literal_pool();
+
+    template<typename T>
+    uint8_t *get_literal_offset(T literal);
+
+    template<typename T>
+    void write(T value);
+};
+
+
+template<typename T>
+inline uint8_t *JitBlock::get_literal_offset(T literal) {
+    uint8_t *ptr;
+    for (ptr = (uint8_t *) code_start - 16; ptr >= literals_start; ptr -= 16) {
+        if (*(T *) ptr == literal) {
+            return ptr;
         }
-};
-
-struct BlockStateHash
-{
-    std::size_t operator()(const BlockState& state) const
-    {
-        std::size_t h1 = std::hash<uint32_t>()(state.pc);
-        std::size_t h2 = std::hash<uint32_t>()(state.prev_pc);
-        std::size_t h3 = std::hash<uint64_t>()(state.program);
-        std::size_t h4 = std::hash<uint64_t>()(state.param1);
-        std::size_t h5 = std::hash<uint64_t>()(state.param2);
-
-        std::size_t result = 0;
-        std::size_t seed = 12345;
-
-        result = (result * seed) + h1;
-        result = (result * seed) + h2;
-        result = (result * seed) + h3;
-        result = (result * seed) + h4;
-        result = (result * seed) + h5;
-
-        return result;
     }
-};
+
+    // didn't find it
+    ptr -= 16;
+    if (ptr < building_block)
+        Errors::die("JIT %s's block is out of room for literals.  Try increasing JIT_MAX_BLOCK_LITERALSIZE",
+                    jit_name.c_str());
+    literals_start = ptr;
+
+    *(T *) ptr = literal;
+
+    return ptr;
+}
 
 
-struct JitBlock
-{
-  BlockState state;
-  void* literals_start;
-  void* code_start;
-  void* code_end;
+template<typename T>
+inline void JitBlock::write(T value) {
+    *(T *) code_end = value;
+    code_end = (uint8_t *) code_end + sizeof(T);
 
-  // page list.
-  JitBlock* next;
-  JitBlock* prev;
+    if (code_end >= building_block + JIT_MAX_BLOCK_CODESIZE + JIT_MAX_BLOCK_LITERALSIZE) {
+        Errors::die("JIT %s's block is out of room for code.  Try increasing JIT_MAX_BLOCK_CODESIZE", jit_name.c_str());
+    }
 
-};
+}
 
 struct FreeList {
-  FreeList* next;
-  FreeList* prev;
-  uint8_t bin;
+    FreeList *next;
+    FreeList *prev;
+    uint8_t bin;
 };
 
-
-class JitCache
+class JitHeap
 {
-    private:
-        // old version had at most 8192 blocks, each 64 kB. this is quite large, let's do 1/128th of it.
-        // all these must have at least 16 byte alignment (or whatever JIT_ALLOC_ALIGN is set to).
-        constexpr static int JIT_CACHE_DEFAULT_SIZE = 8192 * 1024 * 64 / 32;
-        constexpr static int JIT_ALLOC_BINS = 8;
-        constexpr static int JIT_ALLOC_BIN_START = 8; // 2^8 = 256 bytes
-        constexpr static int JIT_MAX_BLOCK_CODESIZE = 1024 * 4096; // 512 kB/block maximum size
-        constexpr static int JIT_MAX_BLOCK_LITERALSIZE = 1024 * 8;
-
-        std::size_t get_min_bin_size(uint8_t bin);
-        std::size_t get_max_bin_size(uint8_t bin);
-        std::size_t* get_size_ptr(void* obj);
-        std::size_t* get_end_ptr(void* obj);
-        void* get_next_object(void* obj);
-        void add_freed_memory_to_bin(void* mem);
-        void remove_memory_from_bin(void* mem);
-        void shrink_object(void* obj, std::size_t size);
-        void* find_memory(std::size_t size);
-        bool merge_fwd(void* mem);
-        bool merge_bwd(void* mem);
-        void init_allocator();
-        void jit_free(void* ptr);
-        void* jit_malloc(std::size_t size);
-        JitBlock** get_ee_page_list_head(uint32_t ee_page);
-        void debug_print_page_list(uint32_t ee_page);
-
-        std::unordered_map<BlockState, JitBlock, BlockStateHash> blocks;
-
-        std::unordered_map<uint32_t, JitBlock*> ee_page_lists;
-
-        JitBlock building_jit_block;
-        uint8_t* building_block;
-
-        JitBlock* current_block;
-
-        std::size_t _heap_size = 0;
-        void* _heap = nullptr;
-        FreeList* free_bin_lists[JIT_ALLOC_BINS + 1];
-
-        uint64_t heap_usage;
-    public:
-        explicit JitCache(std::size_t size = 0);
-        ~JitCache();
-
-        void alloc_block(BlockState state);
-        void free_block(BlockState state);
-        void flush_all_blocks();
-        void invalidate_ee_page(uint32_t page);
-
-        JitBlock *find_block(BlockState state);
-
-        uint8_t* get_current_block_start();
-        uint8_t* get_current_block_pos();
-        void set_current_block_pos(uint8_t* pos);
-
-        void set_current_block_rx();
-        void print_current_block();
-        void print_literal_pool();
-
-        template <typename T> uint8_t* get_literal_offset(T literal);
-        template <typename T> void write(T value);
+protected:
+    void* rwx_alloc(std::size_t size);
+    void rwx_free(void* mem, std::size_t size);
 };
 
-template<typename T>
-inline uint8_t* JitCache::get_literal_offset(T literal)
+template<typename DataType, typename HashFunction = std::hash<DataType>>
+class JitUnorderedMapHeap : public JitHeap
 {
-  if(current_block != &building_jit_block) Errors::die("no");
-  uint8_t* ptr;
-  for(ptr = (uint8_t*)current_block->code_start - 16; ptr >= current_block->literals_start; ptr -= 16) {
-    if(*(T*)ptr == literal) {
-      return ptr;
-    }
-  }
+private:
+    constexpr static int JIT_HEAP_DEFAULT_SIZE = 64 * 1024 * 1024;
+    std::unordered_map<DataType, JitBlockRecord<DataType>, HashFunction> block_map;
+};
 
-  // didn't find it
-  ptr -= 16;
-  if(ptr < building_block) Errors::die("out of room for literals");
-  current_block->literals_start = ptr;
+struct EEJitBlockRecordData {
+    // state
+    uint32_t pc;
 
-  *(T*)ptr = literal;
+    // lookup data structures
+    JitBlockRecord<EEJitBlockRecordData> *next;
+    JitBlockRecord<EEJitBlockRecordData> *prev;
+};
 
-  return ptr;
-}
+using EEJitBlockRecord = JitBlockRecord<EEJitBlockRecordData>;
 
 
-template<typename T>
-inline void JitCache::write(T value)
+class EEJitHeap : public JitHeap
 {
-  if(current_block != &building_jit_block) Errors::die("no");
-  *(T*)current_block->code_end = value;
-  current_block->code_end = (uint8_t*)current_block->code_end + sizeof(T);
+private:
+    // allocator constants
+    constexpr static int EE_JIT_HEAP_SIZE = 64 * 1024 * 1024;
+    constexpr static int JIT_ALLOC_BINS = 8;
+    constexpr static int JIT_ALLOC_BIN_START = 8; // 2^8 = 256 bytes
 
-  if(current_block->code_end >= building_block + JIT_MAX_BLOCK_CODESIZE + JIT_MAX_BLOCK_LITERALSIZE) {
-    Errors::die("no more room for the codes");
-  }
+    // allocator methods
+    std::size_t get_min_bin_size(uint8_t bin);
+    std::size_t get_max_bin_size(uint8_t bin);
+    std::size_t *get_size_ptr(void *obj);
+    std::size_t *get_end_ptr(void *obj);
+    void *get_next_object(void *obj);
+    void add_freed_memory_to_bin(void *mem);
+    void remove_memory_from_bin(void *mem);
+    void shrink_object(void *obj, std::size_t size);
+    void *find_memory(std::size_t size);
+    bool merge_fwd(void *mem);
+    bool merge_bwd(void *mem);
+    void init_allocator();
+    void jit_free(void *ptr);
+    void *jit_malloc(std::size_t size);
 
-}
+    // page list methods
+    EEJitBlockRecord **get_ee_page_list_head(uint32_t ee_page);
+    void debug_print_page_list(uint32_t ee_page);
+
+    // lookup stuff
+    std::unordered_map<uint32_t, EEJitBlockRecord> blocks;
+    std::unordered_map<uint32_t, EEJitBlockRecord *> ee_page_lists;
+
+    // allocator
+    std::size_t _heap_size = 0;
+    void *_heap = nullptr;
+    FreeList *free_bin_lists[JIT_ALLOC_BINS + 1];
+    uint64_t heap_usage;
+
+public:
+    EEJitHeap();
+    ~EEJitHeap();
+
+    EEJitBlockRecord *insert_block(uint32_t PC, JitBlock* block);
+    void free_block(uint32_t PC);
+    void flush_all_blocks();
+    void invalidate_ee_page(uint32_t page);
+    EEJitBlockRecord *find_block(uint32_t PC);
+
+};
 
 
 #endif // JITCACHE_HPP

--- a/src/qt/emuthread.cpp
+++ b/src/qt/emuthread.cpp
@@ -231,10 +231,10 @@ void EmuThread::run()
                 {
                     chrono::system_clock::time_point now = chrono::system_clock::now();
                     chrono::duration<double> elapsed_seconds = now - old_frametime;
-                    FPS = 1 / elapsed_seconds.count();
+                    FPS = 1.0 / elapsed_seconds.count();
                 } while (FPS > 60.0);
                 old_frametime = chrono::system_clock::now();
-                emit update_FPS((int)round(FPS));
+                emit update_FPS(FPS);
             }
             catch (non_fatal_error &error)
             {

--- a/src/qt/emuthread.hpp
+++ b/src/qt/emuthread.hpp
@@ -62,7 +62,7 @@ class EmuThread : public QThread
         void run() override;
     signals:
         void completed_frame(uint32_t* buffer, int inner_w, int inner_h, int final_w, int final_h);
-        void update_FPS(int FPS);
+        void update_FPS(double FPS);
         void emu_error(QString err);
         void emu_non_fatal_error(QString err);
     public slots:

--- a/src/qt/emuwindow.cpp
+++ b/src/qt/emuwindow.cpp
@@ -532,13 +532,25 @@ void EmuWindow::update_FPS(double FPS)
 {
     if(FPS > 0.01) {
         frametime_avg = 0.8 * frametime_avg + 0.2 / FPS;
+        frametime_list[frametime_list_index] = 1. / FPS;
+        frametime_list_index = (frametime_list_index + 1) % 60;
     }
+
+    double worst_frame_time = 0;
+    for(int i = 0; i < 60; i++)
+    {
+        if(frametime_list[i] > worst_frame_time) worst_frame_time = frametime_list[i];
+    }
+
+
 
     framerate_avg = 0.8 * framerate_avg + 0.2 * FPS;
 
     // avoid multiple copies
-    QString status = QString("FPS: %1 (%2 ms)- %3 [EE: %4] [VU1: %5]").arg(
-        QString::number(framerate_avg, 'f', 1), QString::number(frametime_avg * 1000., 'f', 1), current_ROM.fileName(), ee_mode, vu1_mode
+    QString status = QString("FPS: %1 (%2 ms, %3 ms worst)- %4 [EE: %5] [VU1: %6]").arg(
+        QString::number(framerate_avg, 'f', 1), QString::number(frametime_avg * 1000., 'f', 1),
+        QString::number(worst_frame_time * 1000., 'f', 1),
+        current_ROM.fileName(), ee_mode, vu1_mode
     );
 
     setWindowTitle(status);

--- a/src/qt/emuwindow.hpp
+++ b/src/qt/emuwindow.hpp
@@ -22,6 +22,8 @@ class EmuWindow : public QMainWindow
         QString vu1_mode;
         std::chrono::system_clock::time_point old_frametime;
         double framerate_avg, frametime_avg;
+        double frametime_list[60];
+        int frametime_list_index = 0;
 
         QFileInfo current_ROM;
         QMenu* file_menu;

--- a/src/qt/emuwindow.hpp
+++ b/src/qt/emuwindow.hpp
@@ -20,8 +20,7 @@ class EmuWindow : public QMainWindow
         EmuThread emu_thread;
         QString vu1_mode;
         std::chrono::system_clock::time_point old_frametime;
-        std::chrono::system_clock::time_point old_update_time;
-        double framerate_avg;
+        double framerate_avg, frametime_avg;
 
         QFileInfo current_ROM;
         QMenu* file_menu;
@@ -65,7 +64,7 @@ class EmuWindow : public QMainWindow
         void release_key(PAD_BUTTON button);
         void update_joystick(JOYSTICK joystick, JOYSTICK_AXIS axis, uint8_t val);
     public slots:
-        void update_FPS(int FPS);
+        void update_FPS(double FPS);
         void open_file_no_skip();
         void open_file_skip();
         void load_state();


### PR DESCRIPTION
Now the JIT "heap" is specialized for the specific JIT.  The VU/GS JITs basically do the same thing they used to, but now have hash/equality functions that only hash/compare relevant data.  std::hash<uint64_t> as avoided because it involves loops and branching on MSVC.

The EE Jit has a new strategy, which is to have an array per page of EE code. These page arrays are stored an unordered_map, with the EE page number as the key. Each array will have an entry for all of the 1024 possible PCs of the page.  Each entry in the array points to the relevant Jit heap block for the PC.  Lookups in the unordered_map are cached, as consecutive blocks often occur in the same page.

There's also some changes to the FPS counter.  The old one could be very misleading in some cases.  Also it includes ms/frame, which is easier work with than FPS. 

Remaining issues

- invalidate on DMA
- current invalidate is "greedy" (check all PCs, free EE page array). Perhaps the "lazy" approach would be faster? (mark invalid, then always check page array for "valid" setting before using?), only free EE page array memory if we allocate a lot of them.
- performance/bugs on windows/other games (I'm currently away from my desktop and hard drive of PS2 games)